### PR TITLE
[WIP] Fonctions arbre taxo

### DIFF
--- a/data/taxhubdb.sql
+++ b/data/taxhubdb.sql
@@ -356,12 +356,18 @@ CREATE OR REPLACE FUNCTION taxonomie.find_cdref_sp(id integer)
  RETURNS integer
  LANGUAGE plpgsql
  STABLE
-AS $function$
---fonction permettant de renvoyer le cd_ref d'un espèce a partir de son cd_nom ou du cd_nom d'une sous-espece. Utile pour dénombrer la richesse spécifique.
+ AS $function$
+ --fonction permettant de renvoyer le cd_ref d'un espèce a partir de son cd_nom ou du cd_nom d'une sous-espece (null si rang != ES ou SSES)
   DECLARE ref integer;
+  DECLARE rang varchar;
   BEGIN
-	SELECT INTO ref 
-		taxonomie.find_parent(id,'ES',true);
+    SELECT INTO rang id_rang FROM taxonomie.taxref WHERE cd_nom=taxonomie.find_cdref(id);
+    IF rang='ES' THEN
+        ref=taxonomie.find_cdref(id);
+    ELSE
+	    SELECT INTO ref 
+		    taxonomie.find_parent(id,'ES',true);
+    END IF;
 	return ref;
   END;
 $function$


### PR DESCRIPTION
L’objectif est d'améliorer le système permettant de parcourir l'arbre taxonomique :

- Création d'une VM _taxref_tree_parents_ listant les taxons ayant un lien de parenté. Un entier "distance" est ajouté, car le numéro du rang ne suffisait pas, certains taxons ayant plusieurs parents avec id_rang='CLADE') (@DonovanMaillard )

- Modification des fonction _find_all_taxons_children_ pour utiliser par défaut la vm plutôt que de faire une requetes recursives sur le taxref. Un paramètre optionnel _use_vm_ permet de forcer l'utilisation récursive du Taxref (plus lent, mais surtout utile pour construire la vm).

- Ajout d'une fonction _find_all_taxons_parents_ pour lister les parents d'un taxon (jusqu'au domaine). La fonction retourne une table avec le cd_nom du parent, le rang du parent et la distance par rapport au taxon. La distance est différente du tri_rang pour gérer le problème des niveaux 'CLADE' dupliqués (@DonovanMaillard )

- Ajout d'une fonction _find_parent(cd_nom, id_rang)_. Retourne le cd_nom d'un parent (rang précisé en paramètre) du taxon. Cette fonction vise à décourager l'utilisation des champs textes "Règne", "Famille", "Ordre", etc.. du taxref.

- Ajout d'une fonction _find_cdref_sp(cd_nom)_. Alias pour _find_parent(cd_nom, 'ES')_. Utile pour dénombrer la richesse spécifique. Peut-être à indexer sur la synthèse ?

- Ajout d'une fonction _find_lowest_common_ancestor(cd_nom int[] )_ qui retourne le cd_nom de l'ancêtre commun le plus proche d'une liste de taxons. (Pas encore de cas d'usage concret, mais peut servir à trouver le taxon à faire remonter à la synthèse dans le cas de la saisie d'un complexe d'espèces).


La PR permet donc d'exploiter plus efficacement l'arbre taxonomique et d'améliorer les performances. L'objectif à plus long terme de cette PR est de pouvoir supprimer les très nombreux champs redondant du Taxref (famille, règne, nom_valide, etc..) et donc de faciliter la gestion/modification du référentiel taxonomique (et diminuer les risques d’incohérence) et rendre TaxHub/GeoNature moins dépendant du référentiel de l'INPN.