### PR TITLE
Fix Stockage des media dans un cloud S3

### DIFF
--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -164,7 +164,7 @@ class S3FileManagerService(FileManagerServiceInterface):
     """
 
     def __init__(self):
-        super.__init__()
+        super().__init__()
         self.s3 = boto3.client(
             "s3",
             aws_access_key_id=current_app.config["S3_KEY"],

--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -2,6 +2,7 @@ import re
 import os
 import math
 import boto3
+import botocore
 import logging
 import requests
 import unicodedata
@@ -187,7 +188,7 @@ class S3FileManagerService(FileManagerServiceInterface):
             self.s3.delete_object(
                 Bucket=current_app.config["S3_BUCKET_NAME"], Key=filepath
             )
-        except AttributeError:  # filepath is None (upload)
+        except botocore.exceptions.ParamValidationError:  # filepath is None (upload)
             pass
 
     def rename_file(self, old_chemin, old_title, new_title):


### PR DESCRIPTION
Fonctionnalité permettant de stocker les media rattachés aux taxons dans un cloud S3 (AWS, OVH, etc..).
Il s'agit d'un moyen économique et souple (1ct/Go/mois + 1ct/Go téléchargé chez OVH) de stocker et servir des fichiers statiques. Testé avec OVH Object Storage.

Je prévois d'ajouter la même fonctionnalité sur GeoNature, où les media sont beaucoup plus nombreux (avec les media d’occurrences notamment).

Si le S3 est activé, l'API retourne, pour chaque media, l'URL directe du fichier (sur le cloud S3). Les miniatures restent cependant stockées sur le serveur de l'application.
Pour activer le support du S3, il suffit de rajouter les paramètres dans le fichier de configuration.

Je n'ai volontairement pas utilisé Flask-S3, car conçu pour stocker l’intégralité des statics (js, css...), et modifie donc entre autre *url_for*. De plus, Flask-S3 ne prévoit pas l'upload/suppression.

Pour la migration des fichiers déjà présents sur le serveur vers le cloud : https://gist.github.com/jbdesbas/3ad43fa81ab29a3716c7ce503162b1be

Si vous utilisez GeoNature-atlas, pensez à mettre à jour le fichier de configuration (``REMOTE_MEDIAS_URL`` et ``REMOTE_MEDIAS_PATH``) et à rafraîchir la VM _atlas.vm_media_.