### PR TITLE
S3 fix

### DIFF
--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -176,7 +176,7 @@ class S3FileManagerService(FileManagerServiceInterface):
 
     def _get_image_object(self, media):
         if media.chemin:
-            img = url_to_image(media.s3_url)
+            img = url_to_image(os.path.join(current_app.config['S3_PUBLIC_URL'], media.chemin))
         else:
             img = url_to_image(media.url)
 

--- a/apptax/taxonomie/repositories.py
+++ b/apptax/taxonomie/repositories.py
@@ -22,7 +22,10 @@ class MediaRepository:
         if self.s3_storage:
             if not force_path:
                 f_media["chemin"] = None
-            f_media["url"] = os.path.join(current_app.config['S3_PUBLIC_URL'], media.chemin)
+            try :
+                f_media["url"] = os.path.join(current_app.config['S3_PUBLIC_URL'], media.chemin)
+            except TypeError: #file is an URL
+                f_media["url"] = media.url
         return f_media
 
     def _populate_data_media(self, media, data):

--- a/apptax/taxonomie/repositories.py
+++ b/apptax/taxonomie/repositories.py
@@ -37,7 +37,10 @@ class MediaRepository:
 
         if "is_public" in data:
             data["is_public"] = bool(data["is_public"])
-
+        
+        if data.get("chemin", False):
+            data["url"] = None
+        
         for k in data:
             if hasattr(TMedias, k) and not data[k] == "null":
                 setattr(media, k, data[k])

--- a/apptax/taxonomie/repositories.py
+++ b/apptax/taxonomie/repositories.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 
 from flask import current_app
 from sqlalchemy.exc import IntegrityError


### PR DESCRIPTION
Correction d'un import oublié.

Pour l'API, utiliser le champs _url_ si _chemin_ est null (--> le media n'est pas un fichier, mais une url externe)

Lors d'un post (édition d'un media), **ne pas** écrire l'URL dans la base si un chemin est renvoyé par le formulaire (c'est à dire que le media est bien un fichier, on ne renseigne PAS son url publique dans la base, mais seulement son chemin)

Ces modifs sont dues au fait que l'on a besoin de l'url publique du fichier pour afficher la vignette, mais qu'on ne souhaite pas stocker cette url dans la base (car déduite de chemin et de la config).

