### PR TITLE
create mv taxref_tree

### DIFF
--- a/data/taxref_tree.sql
+++ b/data/taxref_tree.sql
@@ -1,0 +1,25 @@
+--Construction
+
+CREATE EXTENSION IF NOT EXISTS ltree;
+
+CREATE MATERIALIZED VIEW taxonomie.taxref_tree
+AS WITH RECURSIVE x AS (
+         SELECT t.cd_nom,
+            t.cd_nom::text::ltree AS path
+           FROM taxonomie.taxref t
+          WHERE t.cd_sup IS NULL AND t.cd_nom = t.cd_ref
+        UNION ALL
+         SELECT y.cd_nom,
+            ltree_addtext(x_1.path, y.cd_nom::text) AS path
+           FROM x x_1,
+            taxonomie.taxref y
+          WHERE y.cd_nom = y.cd_ref AND x_1.cd_nom = y.cd_sup
+        )
+ SELECT x.cd_nom,
+    x.path
+   FROM x
+WITH DATA;
+
+-- View indexes:
+CREATE UNIQUE INDEX taxref_tree_cd_nom_idx ON taxonomie.taxref_tree USING btree (cd_nom);
+CREATE INDEX taxref_tree_path_idx ON taxonomie.taxref_tree USING gist (path); -- TRES important pour les perfs


### PR DESCRIPTION
Le [ltree](https://www.postgresql.org/docs/12/ltree.html) (inclue par défaut) ajoute le type de données `ltree` permettant de représenter des chemins dans un arbre taxonomique.

Un index _GIST_ sur le type _ltree_ est alors très efficace pour rechercher des taxons parents/enfants.

## Vue matérialisée

_taxonomie.taxref_tree_
|cd_nom|path                                            |
|------|------------------------------------------------|
|189953|349525.187496.951105.187499.460634.437076.189953|
|191722|349525.187496.951105.187499.460638.437077.191722|
|197552|349525.187496.951105.187499.460638.437077.197552|

Le VM est assez légère et rapide à générer (~140Mo, et 1 minute pour la construire, index compris, sur l'ensemble du taxref).
La colonne _path (ltree)_ contient les cd_noms de l'ensemble des parents, jusqu'à la racine de l'arbre.

J'avais initialement exploré la piste d'une VM type cd_nom | cd_nom_parent, avec pour chaque cd_nom l'ensemble des ancêtres. Mais cette dernière solution était plus lourde, moins performante et moins intuitive.

## Utilisation et exemples

L'opérateur **@>** permet de comparer deux _path_ en utilisant l'index GIST. Il renvoi TRUE si le chemin à gauche est un ancêtre du chemin à droite.
```SQL
-- Compter les taxons enfants présents dans la synthèse (approche avec JOIN)
SELECT
count(*)
FROM gn_synthese.synthese s
JOIN taxonomie.taxref t ON t.cd_nom = s.cd_nom
JOIN taxonomie.taxref_tree tree ON tree.cd_nom = t.cd_ref
JOIN taxonomie.taxref_tree tree_parent ON tree_parent.path @> tree.path
JOIN taxonomie.taxref tparent ON tparent.cd_nom = tree_parent.cd_nom
WHERE tparent.lb_nom = 'Odonata';
```

```SQL
-- Lister les taxons enfants présents dans la synthèse (approche avec WHERE)
SELECT
    DISTINCT tref.lb_nom
FROM gn_synthese.synthese s
JOIN taxonomie.taxref t ON t.cd_nom = s.cd_nom
JOIN taxonomie.taxref tref ON tref.cd_nom = t.cd_ref
JOIN taxonomie.taxref_tree tt ON tt.cd_nom = tref.cd_nom
WHERE 
   (SELECT "path" FROM taxonomie.taxref_tree WHERE cd_nom = 186233  /*chiroptera */   ) @> tt."path"
```


```SQL
-- Générer un jsonb avec les différents ancêtres
SELECT ancestors.lst_ancestors ->> 'CL'::text AS classe,
    ancestors.lst_ancestors ->> 'OR'::text AS ordre,
    ancestors.lst_ancestors ->> 'FM'::text AS famille,
    lb_nom
  FROM taxonomie.taxref t
     JOIN taxonomie.taxref_tree tt ON tt.cd_nom = t.cd_ref
     JOIN LATERAL ( SELECT jsonb_object_agg(taxref.id_rang, taxref.lb_nom) AS lst_ancestors
           FROM taxonomie.taxref_tree
             JOIN taxonomie.taxref ON taxref.cd_nom = taxref_tree.cd_nom
          WHERE tt.path <@ taxref_tree.path) ancestors ON TRUE
      WHERE t.cd_nom = t.cd_ref AND id_rang ='ES';
```


ltree intègre aussi une fonction lca() permettant de trouver les ancêtres communs à une liste de _path_.

```SQL
-- Trouver l’ancêtre commun (= portée taxonomique) d'un JDD
-- Attention, il est possible que le résultat remonte d'un niveau trop haut
-- (cf https://www.postgresql.org/message-id/CAKnjZ0KTVw63SM5wkWqAkNRv5%2B-GPXF8r60vtssvhOWJ3N5otA%40mail.gmail.com) --> fonction a redéfinir ?
SELECT
(SELECT lb_nom FROM taxonomie.taxref WHERE cd_nom =  subpath( lca( array_agg(tt."path") ) ,-1)::text::int ) AS a
FROM gn_synthese.synthese s 
JOIN taxonomie.taxref t USING (cd_nom)
JOIN taxonomie.taxref_tree tt ON tt.cd_nom = t.cd_ref 
WHERE id_dataset = 8
```

## Discussion


Il existe aussi un type _lquery_ qui permet des recherches types _regex_ dans les _path_ (par exemple pour recherche un cd_nom dans un path : ` '*.'||cd_nom||'.*'` , mais c'est plus plus lent que les opérateur permettant de comparer deux _path_.

Il existe plusieurs approches possibles, plus ou moins verbeuses et/ou claires. Les différentes fonctions et opérateurs inclus avec _ltree_ semble couvrir la plupart des usages possibles (subpath, index, nlevel, etc.).

**A voir** : 
https://www.cybertec-postgresql.com/en/postgresql-speeding-up-recursive-queries-and-hierarchic-data/
http://patshaughnessy.net/2017/12/13/saving-a-tree-in-postgres-using-ltree
http://patshaughnessy.net/2017/12/15/looking-inside-postgres-at-a-gist-index
https://docs.postgresql.fr/12/ltree.html
