### PR TITLE
fix: error 403 on media from wikimedia

### DIFF
--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -17,7 +17,7 @@ from werkzeug.utils import secure_filename
 
 from flask import current_app
 
-from apptax.utils.genericfunctions import get_version
+from apptax.utils.genericfunctions import generate_user_agent
 
 try:
     from urllib.request import urlopen
@@ -233,19 +233,12 @@ def url_to_image(url):
     """
         Récupération d'une image à partir d'une url
     """
-    # f = open(os.path.dirname(__file__) + '/../../VERSION', 'r')
-    # print('AAAAAAAAAAAAAA')
-    # for l in f.readlines():
-    #     print(l)
-    # print(f, f.readlines()[1])
-    headers ={'user-agent': f'TaxHub  {get_version()}'}
+    headers ={'user-agent': generate_user_agent()}
     r = requests.get(url, stream=True, headers=headers)
-    logger.error(r.status_code)
     try:
         img = Image.open(io.BytesIO(r.content))
     except IOError:
         raise Exception("Media is not an image")
-    print(url)
     return img
 
 

--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -17,6 +17,8 @@ from werkzeug.utils import secure_filename
 
 from flask import current_app
 
+from apptax.utils.genericfunctions import get_version
+
 try:
     from urllib.request import urlopen
 except Exception:
@@ -231,11 +233,19 @@ def url_to_image(url):
     """
         Récupération d'une image à partir d'une url
     """
-    r = requests.get(url, stream=True)
+    # f = open(os.path.dirname(__file__) + '/../../VERSION', 'r')
+    # print('AAAAAAAAAAAAAA')
+    # for l in f.readlines():
+    #     print(l)
+    # print(f, f.readlines()[1])
+    headers ={'user-agent': f'TaxHub  {get_version()}'}
+    r = requests.get(url, stream=True, headers=headers)
+    logger.error(r.status_code)
     try:
         img = Image.open(io.BytesIO(r.content))
     except IOError:
         raise Exception("Media is not an image")
+    print(url)
     return img
 
 

--- a/apptax/utils/genericfunctions.py
+++ b/apptax/utils/genericfunctions.py
@@ -14,6 +14,7 @@ def get_version() -> str:
     version = open(os.path.dirname(__file__) + '/../../VERSION', 'r').readline().rstrip()
     return version
 
+
 def generate_user_agent() -> str:
     """Generate a generic user-agent description for requests
 
@@ -22,6 +23,8 @@ def generate_user_agent() -> str:
     """
     user_agent = f'TaxHub/{get_version()} (https://github.com/PnX-SI/TaxHub) python-requests/{requests.__version__}'
     return user_agent
+
+
 def calculate_offset_page(limit, offset, page):
     """
         fonction qui calcul les paramètres

--- a/apptax/utils/genericfunctions.py
+++ b/apptax/utils/genericfunctions.py
@@ -3,11 +3,25 @@
     par l'ensemble de l'application
 '''
 import os
+import requests
 
-def get_version():
+def get_version() -> str:
+    """Get TaxHub version from VERSION file
+
+    Returns:
+        str: TaxHub version
+    """
     version = open(os.path.dirname(__file__) + '/../../VERSION', 'r').readline().rstrip()
     return version
 
+def generate_user_agent() -> str:
+    """Generate a generic user-agent description for requests
+
+    Returns:
+        str: generic user-agent
+    """
+    user_agent = f'TaxHub/{get_version()} (https://github.com/PnX-SI/TaxHub) python-requests/{requests.__version__}'
+    return user_agent
 def calculate_offset_page(limit, offset, page):
     """
         fonction qui calcul les paramètres

--- a/apptax/utils/genericfunctions.py
+++ b/apptax/utils/genericfunctions.py
@@ -2,7 +2,11 @@
     Fichier contenant des fonctions utilisées
     par l'ensemble de l'application
 '''
+import os
 
+def get_version():
+    version = open(os.path.dirname(__file__) + '/../../VERSION', 'r').readline().rstrip()
+    return version
 
 def calculate_offset_page(limit, offset, page):
     """


### PR DESCRIPTION
Le chargement des médias issus de [WikiMedia](https://commons.wikimedia.org/wiki/Main_Page) échoue avec une erreur **403**:
```
Error: 403, Forbidden. Please comply with the User-Agent policy: https://meta.wikimedia.org/wiki/User-Agent_policy at Thu, 12 Aug 2021 09:18:51 GMT
```
générant une erreur lors du chargement de l'image par API, ex:
https://demo.geonature.fr/taxhub/api/tmedias/thumbnail/4?h=80&v=80
```
{"id_media": 4, "message": "UnidentifiedImageError('cannot identify image file <_io.BytesIO object at 0x7f5bdc739d00>',)", "success": false}
```
 
Cette PR ajoute un `user-agent` générique aux requêtes de la fonction `url_to_image`.
```
{'user-agent': 'TaxHub/1.8.1 (https://github.com/PnX-SI/TaxHub) python-requests/2.26.0'}
```