### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -195,6 +195,8 @@ Les différentes versions de TaxHub sont disponibles sur le Github du projet (ht
 
   ::
 
+        cd taxhub
+        source venv/bin/activate
         flask db upgrade taxonomie@head
 
 * Une fois que l'installation est terminée et fonctionnelle, vous pouvez supprimer la version précédente de TaxHub (répertoire ``taxhub_old``).


### PR DESCRIPTION
Manquait la mention
        cd taxhub
        source venv/bin/activate

Peut être piégeur si on a déjà activé le venv de GeoNature