### PR TITLE
feat/load-info-media-inpn

### DIFF
--- a/static/app/bib_nom/edit/bibNom-form-controler.js
+++ b/static/app/bib_nom/edit/bibNom-form-controler.js
@@ -252,7 +252,11 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
           };
           $http
             .post(backendCfg.api_url + "tmedias/", payload)
-            .then(() => {
+            .then((response) => {
+              const newMedia = response.data?.media
+              if (newMedia !== undefined) {
+                self.bibNom.medias.push(newMedia)
+              }
               toaster.pop(
                 "info",
                 toasterMsg.mediaInserted.title,

--- a/static/app/bib_nom/edit/bibNom-form-controler.js
+++ b/static/app/bib_nom/edit/bibNom-form-controler.js
@@ -14,6 +14,7 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
   self.showMediaForm=false;
   self.form = $scope.form;
   self.userRightLevel = 0;
+  self.hideInpnButton = backendCfg.hideInpnButton;
   self.inpnLoading = false;
 
   //----------------------Gestion des droits---------------//

--- a/static/app/bib_nom/edit/bibNom-form-controler.js
+++ b/static/app/bib_nom/edit/bibNom-form-controler.js
@@ -243,7 +243,7 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
           payload = {
             cd_ref: cd_nom,
             chemin: null,
-            id_type: 2,
+            id_type: 1,
             is_public: true,
             isFile: false,
             titre: media?.title || "",
@@ -281,6 +281,6 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
     self.inpnLoading = true;
     setInfo(cd_nom);
     setMedia(cd_nom);
-  }; 
+  };
 }
 ]);

--- a/static/app/bib_nom/edit/bibNom-form-controler.js
+++ b/static/app/bib_nom/edit/bibNom-form-controler.js
@@ -38,6 +38,10 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
       title: "API INPN",
       msg: "Information recupérée avec succès",
     },
+    infoPresent: {
+      title: "API INPN",
+      msg: "Il y a déjà une description pour ce taxon, veuillez d'abord la supprimer",
+    },
     inpnError: {
       title: "API INPN",
       msg: "Impossible d'accéder à l'API de l'INPN",
@@ -182,12 +186,16 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
           });
       };
   //------------------------------ Recupération des infos de l'inpn ----------------------------------/
-  function setInfo(cd_nom) {
+  function getAtlasDescription() {
+    return attribut = self.attributsDefList
+    ?.map((item) => item.attributs)[0]
+    ?.filter((item) => item.nom_attribut == "atlas_description")[0];
+  }
+  
+  function setInfo(cd_nom) { 
     url = inpnURL + `${cd_nom}/factsheet`;
     if (self.attributsDefList) {
-      const attribut = self.attributsDefList
-        ?.map((item) => item.attributs)[0]
-        ?.filter((item) => item.nom_attribut == "atlas_description")[0];
+      const attribut = getAtlasDescription()
       if (attribut !== undefined) {
         $http
           .get(url)
@@ -283,7 +291,19 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
   self.getINPNInfo = function () {
     const cd_nom = self.bibNom.cd_nom;
     self.inpnLoading = true;
-    setInfo(cd_nom);
+    const attribut = getAtlasDescription();
+    if (!self.bibNom.attributs_values[attribut.id_attribut]) {
+      setInfo(cd_nom);
+    } else {
+      self.inpnLoading = false;
+      toaster.pop(
+        "info",
+        toasterMsg.infoPresent.title,
+        toasterMsg.infoPresent.msg,
+        5000,
+        "trustedHtml"
+      );
+    }
     setMedia(cd_nom);
   };
 }

--- a/static/app/bib_nom/edit/bibNom-form-controler.js
+++ b/static/app/bib_nom/edit/bibNom-form-controler.js
@@ -14,6 +14,7 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
   self.showMediaForm=false;
   self.form = $scope.form;
   self.userRightLevel = 0;
+  self.inpnLoading = false;
 
   //----------------------Gestion des droits---------------//
   if (loginSrv.getCurrentUser()) {
@@ -27,9 +28,28 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
 
 
   var toasterMsg = {
-    'saveSuccess':{"title":"Taxon enregistré", "msg": "Le taxon a été enregistré avec succès"},
-    'saveError':{"title":"Erreur d'enregistrement"},
-  }
+    saveSuccess: {
+      title: "Taxon enregistré",
+      msg: "Le taxon a été enregistré avec succès",
+    },
+    saveError: { title: "Erreur d'enregistrement" },
+    mediaInserted: { title: "API INPN", msg: "Media inséré avec succès" },
+    infoInserted: {
+      title: "API INPN",
+      msg: "Information recupérée avec succès",
+    },
+    inpnError: {
+      title: "API INPN",
+      msg: "Impossible d'accéder à l'API de l'INPN",
+    },
+    inpnNotFound: {
+      title: "API INPN",
+      msg: "Aucune description trouvée pour ce taxon sur l'API de l'INPN",
+    },
+  };
+
+  const inpnURL = "https://taxref.mnhn.fr/api/taxa/";
+
   var getTaxonsInfo = function (cd_nom) {
     $http.get(backendCfg.api_url + "bibnoms/taxoninfo/"+cd_nom+"?forcePath=True").then(function(response) {
         if (response.data) {
@@ -114,11 +134,17 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
     }
   });
   //------------------------------ Sauvegarde du formulaire ----------------------------------/
-  self.submit = function() {
+  function postBibNom() {
     var params = self.bibNom;
-    var url = backendCfg.api_url +"bibnoms/";
-    if(action == 'edit'){url=url+self.bibNom.id_nom;}
-    $http.post(url, params, { withCredentials: true })
+    var url = backendCfg.api_url + "bibnoms/";
+    if (action == "edit") {
+      url = url + self.bibNom.id_nom;
+    }
+    return $http.post(url, params, { withCredentials: true });
+  }
+
+  self.submit = function() {
+    postBibNom()
     .then(function(response) {
       var data = response.data
       if (data.success == true) {
@@ -155,5 +181,106 @@ function($scope, $routeParams, $http, $uibModal, locationHistoryService, $locati
                return response.data;
           });
       };
+  //------------------------------ Recupération des infos de l'inpn ----------------------------------/
+  function setInfo(cd_nom) {
+    url = inpnURL + `${cd_nom}/factsheet`;
+    if (self.attributsDefList) {
+      const attribut = self.attributsDefList
+        ?.map((item) => item.attributs)[0]
+        ?.filter((item) => item.nom_attribut == "atlas_description")[0];
+      if (attribut !== undefined) {
+        $http
+          .get(url)
+          .then((response) => {
+            self.bibNom.attributs_values[attribut.id_attribut] =
+              response.data.text || "";
+            postBibNom()
+              .then(() =>
+                toaster.pop(
+                  "success",
+                  toasterMsg.saveSuccess.title,
+                  toasterMsg.saveSuccess.msg,
+                  5000,
+                  "trustedHtml"
+                )
+              )
+              .catch(() =>
+                toaster.pop(
+                  "error",
+                  toasterMsg.saveError.title,
+                  response.data.message,
+                  5000,
+                  "trustedHtml"
+                )
+              )
+              .finally(() => (self.inpnLoading = false));
+          })
+          .catch((error) => {
+            let title = toasterMsg.inpnError.title;
+            let msg = toasterMsg.inpnError.msg;
+            let toasterType = "error";
+
+            if (error.status == 404) {
+              title = toasterMsg.inpnNotFound.title;
+              msg = toasterMsg.inpnNotFound.msg;
+              toasterType = "warning";
+            }
+
+            toaster.pop(toasterType, title, msg, 5000, "trustedHtml");
+          })
+          .finally(() => (self.inpnLoading = false));
+      }
+    }
+  }
+
+  function setMedia(cd_nom) {
+    url = inpnURL + `${cd_nom}/media`;
+    has_error = false;
+    $http.get(url).then((response) => {
+      response.data?._embedded?.media.forEach((media) => {
+        const url = media?._links?.file?.href;
+        if (url && !self.bibNom.medias.map((item) => item.url).includes(url)) {
+          payload = {
+            cd_ref: cd_nom,
+            chemin: null,
+            id_type: 2,
+            is_public: true,
+            isFile: false,
+            titre: media?.title || "",
+            auteur: media?.copyright,
+            url: url,
+          };
+          $http
+            .post(backendCfg.api_url + "tmedias/", payload)
+            .then(() => {
+              toaster.pop(
+                "info",
+                toasterMsg.mediaInserted.title,
+                toasterMsg.mediaInserted.msg,
+                2000,
+                "trustedHtml"
+              );
+            })
+            .catch(() =>
+              toaster.pop(
+                "error",
+                toasterMsg.inpnError.title,
+                toasterMsg.inpnError.msg,
+                5000,
+                "trustedHtml"
+              )
+            )
+            .finally(() => (self.inpnLoading = false));
+        }
+      });
+    });
+  }
+
+  self.getINPNInfo = function () {
+    const cd_nom = self.bibNom.cd_nom;
+    self.inpnLoading = true;
+    setInfo(cd_nom);
+    setMedia(cd_nom);
+  }; 
 }
 ]);

--- a/static/app/bib_nom/edit/bibNom-form-tpl.html
+++ b/static/app/bib_nom/edit/bibNom-form-tpl.html
@@ -15,7 +15,7 @@ form .ng-invalid, form .ng-invalid-required {
             <button ng-if="ctrl.bibNom.cd_nom" ng-click="ctrl.openTaxrefDetail(ctrl.bibNom.cd_ref)" tooltip="Voir toutes les informations disponibles concernant le taxon de référence de ce taxons" class="btn btn-success" >
                 <span class="glyphicon glyphicon-eye-open"></span>
             </button>
-            <button ng-disabled="ctrl.inpnLoading" ng-if="ctrl.bibNom.cd_nom" ng-click="ctrl.getINPNInfo()"
+            <button ng-hide="ctrl.hideInpnButton" ng-disabled="ctrl.inpnLoading" ng-if="ctrl.bibNom.cd_nom" ng-click="ctrl.getINPNInfo()"
                 tooltip="Récupérer les informations et les médias depuis l'INPN" class="btn btn-success">
                 <span>Récupérer description et média INPN</span>
             </button>

--- a/static/app/bib_nom/edit/bibNom-form-tpl.html
+++ b/static/app/bib_nom/edit/bibNom-form-tpl.html
@@ -15,6 +15,10 @@ form .ng-invalid, form .ng-invalid-required {
             <button ng-if="ctrl.bibNom.cd_nom" ng-click="ctrl.openTaxrefDetail(ctrl.bibNom.cd_ref)" tooltip="Voir toutes les informations disponibles concernant le taxon de référence de ce taxons" class="btn btn-success" >
                 <span class="glyphicon glyphicon-eye-open"></span>
             </button>
+            <button ng-disabled="ctrl.inpnLoading" ng-if="ctrl.bibNom.cd_nom" ng-click="ctrl.getINPNInfo()"
+                tooltip="Récupérer les informations et les médias depuis l'INPN" class="btn btn-success">
+                <span>Récupérer description et média INPN</span>
+            </button>
         </div>
         <div class="panel-body">
             <form id="tx-form" class="form-horizontal" name="ctrl.form">

--- a/static/app/constants.js.sample
+++ b/static/app/constants.js.sample
@@ -4,5 +4,6 @@ app.constant("backendCfg", {
   "user_admin_privilege":6,
   "user_high_privilege":4,
   "user_medium_privilege":3,
-  "user_low_privilege":2
+  "user_low_privilege":2,
+  "hideInpnButton": false
 })


### PR DESCRIPTION
## Contexte
Suite à plusieurs demandes notamment du PNR de la Forêt D'Orient et de la LPO PACA, un bouton pouvant récupérer automatiquement les informations depuis l'API de l'INPN serait fortement utile pour générer rapidement les fiches espèces, notamment pour l'atlas.

## Implémentation
Un nouveau bouton a été ajouté dans l'édition d'une fiche espèce et récupère depuis 2 routes de l'API INPN la description et les média.
Si une description est déjà présente : elle est écrasée
Si un média est déjà présent (vérifié par l'url) : il n'est pas écrasé

## Limitations
Les médias s'insèrent automatiquement dans la liste mais pas le type de média : il suffit donc de recharger la page. Il faudrait que l'API retourne après le POST/PUT le nom du type de média en plus de l'`id_type`.
Pour le moment il est obligatoire d'insérer en base de donnée l'attribut `atlas_description` (doit **absolument** s'appeler comme cela) en plus d'un thème si besoin:

```sql
INSERT INTO bib_themes (nom_theme, desc_theme, ordre, id_droit) 
VALUES ('Atlas', 'Informations relatives à GeoNature-atlas', 2, 3);

-- Insertion des attributs utilisés par GeoNature-atlas
INSERT INTO bib_attributs (id_attribut, nom_attribut, label_attribut, liste_valeur_attribut, obligatoire, desc_attribut, type_attribut, type_widget, regne, group2_inpn, id_theme, ordre) VALUES (100, 'atlas_description', 'Description', '{}', false, 'Donne une description du taxon pour l''atlas', 'text', 'textarea', NULL, NULL, (SELECT max(id_theme) FROM taxonomie.bib_themes), 1);
```