### PR TITLE
Add PK for taxonomie.import_taxref

### DIFF
--- a/apptax/taxonomie/commands/migrate_to_v15/commands.py
+++ b/apptax/taxonomie/commands/migrate_to_v15/commands.py
@@ -165,7 +165,16 @@ def import_data_taxref_v15():
                 table_name="cdnom_disparu",
                 delimiter=",",
             )
-
+        # Delete doublons
+        logger.info("Add PK for taxonomie.import_taxref")
+        db.session.execute(
+            text(
+                """
+                --- Ajout d'un clé primaire à la nouvelle table import_taxref
+                ALTER TABLE taxonomie.import_taxref ADD CONSTRAINT pk_import_taxref PRIMARY KEY (cd_nom);
+                """
+            )
+        )
         # No changes in taxref v15
         # with archive.open('rangs_note.csv') as f:
         #     logger.info("Insert rangs_note tmp table…")


### PR DESCRIPTION
PR par @gildeluermoz 

La table `taxonomie.import_taxref` est créée et peuplée sans clé primaire. Donc sans index. Lors de l'import du nouveau taxref de `taxonomie.import_taxref` vers  `taxonomie.taxref`, la requête ne trouve pas d'index sur le cd_nom de `taxonomie.import_taxref`. Elle est donc  extrêmement longue. En ajoutant la PK, la mise à jour de taxref est incomparablement plus rapide (testé). Syntaxe de la modif non testée. A vérifier donc.

Peut-être qu'il serait plus simple de créer cette PK dans le fichier https://github.com/PnX-SI/TaxHub/tree/master/apptax/taxonomie/commands/migrate_to_v15/data/0_taxrefv15_import_data.sql