### PR TITLE
import BDC_STATUTS_15 en UTF-8

### DIFF
--- a/apptax/taxonomie/commands/migrate_to_v15/commands.py
+++ b/apptax/taxonomie/commands/migrate_to_v15/commands.py
@@ -248,7 +248,6 @@ def import_data_dbc_status_15():
             copy_from_csv(
                 f,
                 table_name="bdc_statut",
-                encoding="WIN1252",
                 delimiter=",",
                 dest_cols=(
                     "cd_nom",


### PR DESCRIPTION
Par @gildeluermoz :

A priori, @bouttier a préparé un fichier en utf-8 sur https://geonature.fr/data/inpn/taxonomie/BDC-statuts-15.zip mais la commande indique de charger ce fichier en WIN1252. Le script lève alors une erreur qui n'est pas gérée et stoppe la mise à jour au milieu du gué : 
- la partie migration taxref est faite complètement mais il faut faire qq requêtes en base pour le vérifier. 
- la bdc statuts v14 est purgée
- la bdc_statuts v15 n'est pas insérée. Pour reprendre proprement la migration, j'ai du analyser et modifier le script `commands.py` pour comprendre et retirer ce qui avait déjà été fait.

----------------------------

Voici le retour console de l'erreur sur la commande `flask taxref migrate-to-v15 apply-changes`
```
flask taxref migrate-to-v15 apply-changes
taxref_migration - INFO - Create working copy of bib_noms…
taxref_migration - INFO - List of taxref changes done in tmp
taxref_migration - INFO - Migration of taxref ...
taxref_migration - INFO - it's done
taxref_migration - INFO - Insert BDC_STATUTS_TYPES_15 table…
taxref_migration - INFO - Insert bdc_statut table…
Traceback (most recent call last):
  File "/home/user/taxhub/venv/bin/flask", line 8, in <module>
    sys.exit(main())
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/flask/cli.py", line 1047, in main
    cli.main()
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/flask/cli.py", line 357, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/home/user/taxhub/venv/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/user/taxhub/apptax/taxonomie/commands/migrate_to_v15/commands.py", line 120, in apply_changes
    import_and_format_dbc_status()
  File "/home/user/taxhub/apptax/taxonomie/commands/migrate_to_v15/commands.py", line 184, in import_and_format_dbc_status
    import_data_dbc_status_15()
  File "/home/user/taxhub/apptax/taxonomie/commands/migrate_to_v15/commands.py", line 254, in import_data_dbc_status_15
    "cd_nom",
  File "/home/user/taxhub/apptax/taxonomie/commands/utils.py", line 259, in copy_from_csv
    f,
psycopg2.errors.UntranslatableCharacter: ERREUR:  le caractère dont la séquence d'octets est 0x81 dans l'encodage « WIN1252 » n'a pas
d'équivalent dans l'encodage « UTF8 »
CONTEXT:  COPY bdc_statut, ligne 16339
```
En modifiant le fichier `commands.py` et en y retirant ce qui avait déjà été fait, j'ai pu poursuivre et a priori finir proprement
```
(venv) user@vps-xxxx:~/taxhub$ flask taxref migrate-to-v15 apply-changes
taxref_migration - INFO - Insert BDC_STATUTS_TYPES_15 table…
taxref_migration - INFO - Insert bdc_statut table…
taxref_migration - INFO - Remove duplicate bdc_statut
taxref_migration - INFO - Import raw bdc_statut into structured table
taxref_migration - INFO - Clean DB
``` 