### PR TITLE
feat: make scripts portable across unix systems

### DIFF
--- a/data/scripts/update_taxref/apply_changes.sh
+++ b/data/scripts/update_taxref/apply_changes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ../../../settings.ini
 

--- a/data/scripts/update_taxref/clean_db.sh
+++ b/data/scripts/update_taxref/clean_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ../../../settings.ini
 

--- a/data/scripts/update_taxref/import_taxref_v11_data.sh
+++ b/data/scripts/update_taxref/import_taxref_v11_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . ../../../settings.ini
 
 mkdir -p /tmp/taxhub

--- a/data/scripts/update_taxref/import_taxref_v13_data.sh
+++ b/data/scripts/update_taxref/import_taxref_v13_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . ../../../settings.ini
 
 START_RED="\033[0;31m"

--- a/data/scripts/update_taxref/import_taxref_v14.sh
+++ b/data/scripts/update_taxref/import_taxref_v14.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 . ../../../settings.ini
 
 START_RED="\033[0;31m"

--- a/install_app.sh
+++ b/install_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . settings.ini
 

--- a/install_db.sh
+++ b/install_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 


### PR DESCRIPTION
Permet aux développeurs n'ayant pas le $PATH classique /bin/bash (i.e MacOS) de pouvoir executer les scripts d'installation/migration.

Cette notation est plus flexible et permet d'assouplir les restrictions sur l'environnement de développement des collaborateurs.

https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html
