### PR TITLE
perf: changed index on vm_taxref_list_forautocomplete to improve search

### DIFF
--- a/apptax/migrations/versions/3bd542b72955_optimize_vm_taxref_for_autocomplete.py
+++ b/apptax/migrations/versions/3bd542b72955_optimize_vm_taxref_for_autocomplete.py
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "3bd542b72955"
-down_revision = "188bc535258a"
+down_revision = "23c25552d707"
 branch_labels = None
 depends_on = None
 

--- a/apptax/migrations/versions/3bd542b72955_optimize_vm_taxref_for_autocomplete.py
+++ b/apptax/migrations/versions/3bd542b72955_optimize_vm_taxref_for_autocomplete.py
@@ -1,0 +1,113 @@
+"""optimize_vm_taxref_for_autocomplete
+
+Revision ID: 3bd542b72955
+Revises: 188bc535258a
+Create Date: 2023-04-25 09:46:47.311160
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3bd542b72955"
+down_revision = "188bc535258a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        DROP MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete;
+        CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete AS
+        SELECT row_number() OVER () AS gid,
+        t.cd_nom,
+        t.cd_ref,
+        t.search_name,
+        unaccent(t.search_name) AS unaccent_search_name,
+        t.nom_valide,
+        t.lb_nom,
+        t.nom_vern,
+        t.regne,
+        t.group2_inpn
+        FROM ( SELECT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(t_1.lb_nom, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_nom, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn
+                FROM taxonomie.taxref t_1
+                UNION
+                SELECT DISTINCT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(split_part(t_1.nom_vern::text, ','::text, 1), ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_ref, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn
+                FROM taxonomie.taxref t_1
+                WHERE t_1.nom_vern IS NOT NULL AND t_1.cd_nom = t_1.cd_ref
+                )t 
+        WITH DATA;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE INDEX i_tri_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete USING gin (unaccent_search_name gin_trgm_ops);
+        CREATE INDEX i_vm_taxref_list_forautocomplete_cd_nom ON taxonomie.vm_taxref_list_forautocomplete USING btree (cd_nom);
+        CREATE UNIQUE INDEX i_vm_taxref_list_forautocomplete_gid ON taxonomie.vm_taxref_list_forautocomplete USING btree (gid);
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DROP MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete;
+        CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete AS
+        SELECT row_number() OVER () AS gid,
+        t.cd_nom,
+        t.cd_ref,
+        t.search_name,
+        t.nom_valide,
+        t.lb_nom,
+        t.nom_vern,
+        t.regne,
+        t.group2_inpn
+        FROM ( SELECT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(t_1.lb_nom, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_nom, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn
+                FROM taxonomie.taxref t_1
+                UNION
+                SELECT DISTINCT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(split_part(t_1.nom_vern::text, ','::text, 1), ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_ref, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn
+                FROM taxonomie.taxref t_1
+                WHERE t_1.nom_vern IS NOT NULL AND t_1.cd_nom = t_1.cd_ref
+                )t 
+        WITH DATA;       
+        """
+    )
+
+    op.execute(
+        """
+        CREATE unique INDEX i_vm_taxref_list_forautocomplete_gid ON taxonomie.vm_taxref_list_forautocomplete (gid);
+        CREATE INDEX i_vm_taxref_list_forautocomplete_cd_nom ON taxonomie.vm_taxref_list_forautocomplete (cd_nom ASC NULLS LAST);
+        CREATE INDEX i_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete (search_name ASC NULLS LAST);
+        CREATE INDEX i_tri_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete USING gist (search_name  gist_trgm_ops);
+        """
+    )

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -230,6 +230,7 @@ class VMTaxrefListForautocomplete(db.Model):
     gid = db.Column(db.Integer, primary_key=True)
     cd_nom = db.Column(db.Integer)
     search_name = db.Column(db.Unicode)
+    unaccent_search_name = db.Column(db.Unicode)
     cd_ref = db.Column(db.Integer)
     nom_valide = db.Column(db.Unicode)
     lb_nom = db.Column(db.Unicode)

--- a/apptax/taxonomie/routestaxref.py
+++ b/apptax/taxonomie/routestaxref.py
@@ -408,9 +408,9 @@ def get_AllTaxrefNameByListe(code_liste=None):
     data = q.paginate(page=page, per_page=limit, error_out=False)
 
     if search_name:
-        return [d[0].as_dict() for d in data.items]
+        return [d[0].as_dict(exclude=["unaccent_search_name"]) for d in data.items]
     else:
-        return [d.as_dict() for d in data.items]
+        return [d.as_dict(exclude=["unaccent_search_name"]) for d in data.items]
 
 
 @adresses.route("/bib_habitats", methods=["GET"])

--- a/apptax/taxonomie/routestaxref.py
+++ b/apptax/taxonomie/routestaxref.py
@@ -373,11 +373,13 @@ def get_AllTaxrefNameByListe(code_liste=None):
     search_name = request.args.get("search_name")
     if search_name:
         q = q.add_columns(
-            func.similarity(VMTaxrefListForautocomplete.search_name, search_name).label("idx_trgm")
+            func.similarity(VMTaxrefListForautocomplete.unaccent_search_name, search_name).label(
+                "idx_trgm"
+            )
         )
         search_name = search_name.replace(" ", "%")
         q = q.filter(
-            func.unaccent(VMTaxrefListForautocomplete.search_name).ilike(
+            VMTaxrefListForautocomplete.unaccent_search_name.ilike(
                 func.unaccent("%" + search_name + "%")
             )
         ).order_by(desc("idx_trgm"))


### PR DESCRIPTION
Tout est résumé par l'issue #384 et en plus de cela, l'index suivant a été supprimé : 
```sql
CREATE INDEX i_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete (search_name ASC NULLS LAST);
```

Closes https://github.com/PnX-SI/TaxHub/issues/384