### PR TITLE
Correction downgrade 6607b25b2d66

### DIFF
--- a/apptax/migrations/versions/6607b25b2d66_taxref_set_null_to_empty_string.py
+++ b/apptax/migrations/versions/6607b25b2d66_taxref_set_null_to_empty_string.py
@@ -46,8 +46,8 @@ def upgrade():
 def downgrade():
     op.execute(
         """
-        UPDATE taxonomie.taxref SET id_statut = '' WHERE id_statut IS NULL;
-        UPDATE taxonomie.taxref SET id_rang = '' WHERE id_rang IS NULL;
+        UPDATE taxonomie.taxref SET id_statut = '' WHERE id_statut IS NULL AND id_statut IN (SELECT id_statut FROM taxonomie.bib_taxref_statuts );
+        UPDATE taxonomie.taxref SET id_rang = '' WHERE id_rang IS NULL AND id_rang IN (SELECT id_rang FROM taxonomie.bib_taxref_statuts );
         UPDATE taxonomie.taxref SET regne = '' WHERE regne IS NULL;
         UPDATE taxonomie.taxref SET phylum = '' WHERE phylum IS NULL;
         UPDATE taxonomie.taxref SET classe = '' WHERE classe IS NULL;


### PR DESCRIPTION
```py
INFO  [alembic.runtime.migration] Running downgrade 6607b25b2d66 -> 23c25552d707, Taxref : set null to empty string
Traceback (most recent call last):
  File " TaxHub/venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File " TaxHub/venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.ForeignKeyViolation: insert or update on table "taxref" violates foreign key constraint "taxref_id_statut_fkey"
DETAIL:  Key (id_statut)=( ) is not present in table "bib_taxref_statuts".
```
