### PR TITLE
feat(db): group3_inpn vm autocomplete

### DIFF
--- a/apptax/migrations/versions/8f3256f60915_group3_inpn_autocomplete.py
+++ b/apptax/migrations/versions/8f3256f60915_group3_inpn_autocomplete.py
@@ -1,0 +1,110 @@
+"""group3_inpn_autocomplete
+
+Revision ID: 8f3256f60915
+Revises: 32c5ed42bdbd
+Create Date: 2023-09-04 11:06:36.395886
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8f3256f60915"
+down_revision = "32c5ed42bdbd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete")
+    op.execute(
+        """
+    CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete
+        TABLESPACE pg_default
+        AS SELECT row_number() OVER () AS gid,
+            t.cd_nom,
+            t.cd_ref,
+            t.search_name,
+            unaccent(t.search_name) AS unaccent_search_name,
+            t.nom_valide,
+            t.lb_nom,
+            t.nom_vern,
+            t.regne,
+            t.group2_inpn,
+            t.group3_inpn
+        FROM ( SELECT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(t_1.lb_nom, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_nom, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn,
+                    t_1.group3_inpn
+                FROM taxonomie.taxref t_1
+                UNION
+                SELECT DISTINCT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(split_part(t_1.nom_vern::text, ','::text, 1), ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_ref, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn,
+                    t_1.group3_inpn
+                FROM taxonomie.taxref t_1
+                WHERE t_1.nom_vern IS NOT NULL AND t_1.cd_nom = t_1.cd_ref) t
+        WITH DATA;
+
+        -- View indexes:
+        CREATE INDEX i_tri_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete USING gin (unaccent_search_name gin_trgm_ops);
+        CREATE INDEX i_vm_taxref_list_forautocomplete_cd_nom ON taxonomie.vm_taxref_list_forautocomplete USING btree (cd_nom);
+        CREATE UNIQUE INDEX i_vm_taxref_list_forautocomplete_gid ON taxonomie.vm_taxref_list_forautocomplete USING btree (gid);
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete
+        TABLESPACE pg_default
+        AS SELECT row_number() OVER () AS gid,
+            t.cd_nom,
+            t.cd_ref,
+            t.search_name,
+            unaccent(t.search_name) AS unaccent_search_name,
+            t.nom_valide,
+            t.lb_nom,
+            t.nom_vern,
+            t.regne,
+            t.group2_inpn
+        FROM ( SELECT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(t_1.lb_nom, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_nom, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn
+                FROM taxonomie.taxref t_1
+                UNION
+                SELECT DISTINCT t_1.cd_nom,
+                    t_1.cd_ref,
+                    concat(split_part(t_1.nom_vern::text, ','::text, 1), ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_ref, ']') AS search_name,
+                    t_1.nom_valide,
+                    t_1.lb_nom,
+                    t_1.nom_vern,
+                    t_1.regne,
+                    t_1.group2_inpn
+                FROM taxonomie.taxref t_1
+                WHERE t_1.nom_vern IS NOT NULL AND t_1.cd_nom = t_1.cd_ref) t
+        WITH DATA;
+
+        -- View indexes:
+        CREATE INDEX i_tri_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete USING gin (unaccent_search_name gin_trgm_ops);
+        CREATE INDEX i_vm_taxref_list_forautocomplete_cd_nom ON taxonomie.vm_taxref_list_forautocomplete USING btree (cd_nom);
+        CREATE UNIQUE INDEX i_vm_taxref_list_forautocomplete_gid ON taxonomie.vm_taxref_list_forautocomplete USING btree (gid);
+"""
+    )

--- a/apptax/migrations/versions/8f3256f60915_group3_inpn_autocomplete.py
+++ b/apptax/migrations/versions/8f3256f60915_group3_inpn_autocomplete.py
@@ -66,6 +66,7 @@ def upgrade():
 
 
 def downgrade():
+    op.execute("DROP MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete")
     op.execute(
         """
         CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete

--- a/apptax/migrations/versions/8f3256f60915_group3_inpn_autocomplete.py
+++ b/apptax/migrations/versions/8f3256f60915_group3_inpn_autocomplete.py
@@ -1,7 +1,7 @@
 """group3_inpn_autocomplete
 
 Revision ID: 8f3256f60915
-Revises: 32c5ed42bdbd
+Revises: 33e20a7682b4
 Create Date: 2023-09-04 11:06:36.395886
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "8f3256f60915"
-down_revision = "32c5ed42bdbd"
+down_revision = "33e20a7682b4"
 branch_labels = None
 depends_on = None
 

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -237,6 +237,7 @@ class VMTaxrefListForautocomplete(db.Model):
     nom_vern = db.Column(db.Unicode)
     regne = db.Column(db.Unicode)
     group2_inpn = db.Column(db.Unicode)
+    group3_inpn = db.Column(db.Unicode)
 
     def __repr__(self):
         return "<VMTaxrefListForautocomplete  %r>" % self.search_name

--- a/apptax/taxonomie/routestaxref.py
+++ b/apptax/taxonomie/routestaxref.py
@@ -413,6 +413,10 @@ def get_AllTaxrefNameByListe(code_liste=None):
     if group2_inpn:
         q = q.filter(VMTaxrefListForautocomplete.group2_inpn == group2_inpn)
 
+    group3_inpn = request.args.get("group3_inpn")
+    if group3_inpn:
+        q = q.filter(VMTaxrefListForautocomplete.group3_inpn == group3_inpn)
+
     limit = request.args.get("limit", 20, int)
     page = request.args.get("page", 1, int)
     if "offset" in request.args:

--- a/apptax/tests/test_taxref.py
+++ b/apptax/tests/test_taxref.py
@@ -49,6 +49,22 @@ class TestAPITaxref:
         if data:
             assert self.schema_allnamebyListe.is_valid(data)
 
+    def test_get_allnamebyListe_routes_without_list_filter_group3(self):
+        query_string = {
+            "limit": 10,
+            "search_name": "poa",
+            "regne": "Plantae",
+            "group2_inpn": "Angiospermes",
+            "group3_inpn": "Autres",
+        }
+        response = self.client.get(
+            url_for("taxref.get_AllTaxrefNameByListe", code_liste=-1), query_string=query_string
+        )
+        assert response.status_code == 200
+        data = response.json
+        if data:
+            assert self.schema_allnamebyListe.is_valid(data)
+
     def test_get_distinct_routes(self):
         response = self.client.get(url_for("taxref.getDistinctField", field="regne"))
         assert response.status_code == 200

--- a/apptax/tests/test_taxref.py
+++ b/apptax/tests/test_taxref.py
@@ -19,6 +19,7 @@ class TestAPITaxref:
                 "lb_nom": str,
                 "regne": str,
                 "group2_inpn": str,
+                "group3_inpn": str,
             }
         ]
     )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,8 @@
 **🚀 Nouveautés**
 
 * Ajout d'une fonction `taxonomie.check_is_group3inpn(mygroup text)` qui permet de tester si une chaine de caractère correspond bien à un group3_inpn (#433).
+* Ajout de la colonne `group3_inpn` à la vue materialisée `vm_taxref_list_forautocomplete` et d'un filtre `group3_inpn` a la route `allnamebylist` (#432).
+
 
 1.12.1 (2023-09-12)
 ===================

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,13 +5,17 @@
 
 *
 
+**🚀 Nouveautés**
+
+* Ajout d'une fonction `taxonomie.check_is_group3inpn(mygroup text)` qui permet de tester si une chaine de caractère correspond bien à un group3_inpn (#433).
+
 1.12.1 (2023-09-12)
 ===================
 
 **🐛 Corrections**
 
 * [Migration Taxref] Ajout de scripts SQL manquants dans le fichier `setup.py` (#430)
-* [Migration Taxref] Ne pas spécifier de répertoire de fichier de données dans la fonction `open_remote_file(...,"TAXREF_v16_2022.zip", ...)`, afin de pouvoir utiliser la variable d'environnement `DATA_PATH` (#430) 
+* [Migration Taxref] Ne pas spécifier de répertoire de fichier de données dans la fonction `open_remote_file(...,"TAXREF_v16_2022.zip", ...)`, afin de pouvoir utiliser la variable d'environnement `DATA_PATH` (#430)
 
 **💻 Développement**
 


### PR DESCRIPTION
Ajout de la colonne `group3_inpn` à la vue materialisée `vm_taxref_list_forautocomplete`

Cette PR entre dans le cadre de l'ajout du group3_inpn pour le filtrage dans les nomenclatures saisissables dans occtax. Ceci dans le cadre d'une prestation pour l'Agence Régionale pour la Biodiversité en île de France