### PR TITLE
feat(db): add vm and function to check group3_inpn

### DIFF
--- a/apptax/migrations/versions/33e20a7682b4_check_group3_inpn_vm_function.py
+++ b/apptax/migrations/versions/33e20a7682b4_check_group3_inpn_vm_function.py
@@ -19,14 +19,8 @@ depends_on = None
 def upgrade():
     op.execute(
         """
-               CREATE MATERIALIZED VIEW taxonomie.vm_group3_inpn
-                TABLESPACE pg_default
-                AS SELECT DISTINCT tx.group3_inpn
-                FROM taxonomie.taxref tx
-                WHERE tx.group3_inpn notnull
-                WITH DATA;
-                CREATE UNIQUE INDEX i_unique_group3_inpn ON taxonomie.vm_group3_inpn USING btree (group3_inpn);
-               """
+            CREATE INDEX i_taxref_group3_inpn ON taxonomie.taxref USING btree (group3_inpn);
+        """
     )
 
     op.execute(
@@ -38,7 +32,7 @@ def upgrade():
                 AS $function$
                 --fonction permettant de vérifier si un texte proposé correspond à un group3_inpn dans la table taxref
                 BEGIN
-                    IF mygroup IN(SELECT group3_inpn FROM taxonomie.vm_group3_inpn) OR mygroup IS NULL THEN
+                    IF EXISTS (SELECT 1 FROM taxonomie.taxref WHERE group3_inpn = mygroup ) OR mygroup IS NULL THEN
                     RETURN true;
                     ELSE
                     RETURN false;
@@ -51,5 +45,5 @@ def upgrade():
 
 
 def downgrade():
-    op.execute("DROP MATERIALIZED VIEW taxonomie.vm_group3_inpn")
+    op.execute("DROP INDEX taxonomie.i_taxref_group3_inpn")
     op.execute("DROP FUNCTION taxonomie.check_is_group3inpn")

--- a/apptax/migrations/versions/33e20a7682b4_check_group3_inpn_vm_function.py
+++ b/apptax/migrations/versions/33e20a7682b4_check_group3_inpn_vm_function.py
@@ -1,0 +1,55 @@
+"""check_group3_inpn_vm_and_function
+
+Revision ID: 33e20a7682b4
+Revises: 32c5ed42bdbd
+Create Date: 2023-09-04 08:23:34.336383
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "33e20a7682b4"
+down_revision = "32c5ed42bdbd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+               CREATE MATERIALIZED VIEW taxonomie.vm_group3_inpn
+                TABLESPACE pg_default
+                AS SELECT DISTINCT tx.group3_inpn
+                FROM taxonomie.taxref tx
+                WHERE tx.group3_inpn notnull
+                WITH DATA;
+                CREATE UNIQUE INDEX i_unique_group3_inpn ON taxonomie.vm_group3_inpn USING btree (group3_inpn);
+               """
+    )
+
+    op.execute(
+        """
+                CREATE OR REPLACE FUNCTION taxonomie.check_is_group3inpn(mygroup text)
+                RETURNS boolean
+                LANGUAGE plpgsql
+                IMMUTABLE
+                AS $function$
+                --fonction permettant de vérifier si un texte proposé correspond à un group3_inpn dans la table taxref
+                BEGIN
+                    IF mygroup IN(SELECT group3_inpn FROM taxonomie.vm_group3_inpn) OR mygroup IS NULL THEN
+                    RETURN true;
+                    ELSE
+                    RETURN false;
+                    END IF;
+                END;
+                $function$;
+
+"""
+    )
+
+
+def downgrade():
+    op.execute("DROP MATERIALIZED VIEW taxonomie.vm_group3_inpn")
+    op.execute("DROP FUNCTION taxonomie.check_is_group3inpn")


### PR DESCRIPTION
Ajout de la fonction et de la vue matérialisée associée pour vérifier que la chaîne de caractère fournie est bien un groupe 3 inpn.

Ceci est nécessaire à l'ajout de la possibilité de filtrer les nomenclature selon le groupe 3 inpn. Cette PR s'inscrit dans le cadre d'une prestation pour l'Agence Régionale de la Biodiversité en île de France.