### PR TITLE
Join taxref medias and attributes on cd_nom

### DIFF
--- a/apptax/admin/filters.py
+++ b/apptax/admin/filters.py
@@ -6,6 +6,7 @@ from flask_admin.model.filters import BaseFilter
 from flask_admin.contrib.sqla.filters import FilterEqual
 from flask_admin.babel import lazy_gettext
 
+from sqlalchemy.orm import aliased
 
 from apptax.taxonomie.models import (
     Taxref,
@@ -77,7 +78,9 @@ class FilterIsValidName(BaseFilter):
 
 class FilterMedia(BaseFilter):
     def apply(self, query, value, alias=None):
-        medias_filter = Taxref.medias.any()
+        TaxonValid = aliased(Taxref)
+        query = query.join(TaxonValid, Taxref.cd_ref == TaxonValid.cd_ref)
+        medias_filter = TaxonValid.medias.any()
         if int(value) == 1:
             return query.filter(medias_filter)
         else:
@@ -89,7 +92,9 @@ class FilterMedia(BaseFilter):
 
 class FilterAttributes(BaseFilter):
     def apply(self, query, value, alias=None):
-        attr_filter = Taxref.attributs.any()
+        TaxonValid = aliased(Taxref)
+        query = query.join(TaxonValid, Taxref.cd_ref == TaxonValid.cd_ref)
+        attr_filter = TaxonValid.attributs.any()
         if int(value) == 1:
             return query.filter(attr_filter)
         else:

--- a/apptax/admin/templates/admin/details_taxref.html
+++ b/apptax/admin/templates/admin/details_taxref.html
@@ -14,7 +14,7 @@
                 <h5 class="card-title col-1">
                   <a href="https://inpn.mnhn.fr/espece/cd_nom/{{model.cd_nom }}">
                     <img width="100" src="{{url_for("static", filename="logo_inpn.png")}}" alt="">
-                   </a>    
+                   </a>
                 </h5>
               </div>
               <div class="card-subtitle mb-2 text-muted" id="taxonomie-hierarchy">
@@ -44,16 +44,16 @@
               <div class="tab-pane fade mt-3" id="nav-status" role="tabpanel" aria-labelledby="nav-status-tab">
                   <a target="_blank" href="https://inpn.mnhn.fr/espece/cd_nom/{{model.cd_nom}}/tab/statut" class="btn mb-2 btn-primary ">
                     Voir les status sur la fiche INPN
-                  </a> 
+                  </a>
                   {% for statut in model.status %}
                     <div class="alert alert-success">
                       {{statut.lb_type_statut}}
                     </div>
-                    <b> {{statut.full_citation}} </b> 
+                    <b> {{statut.full_citation}} </b>
                     <p>
                       <b>Portée : </b> {{statut.niveau_admin}} - {{statut.cd_sig}} <br>
                       <b>Niveau : </b> {{statut.niveau_admin}} - {{statut.label_statut}} <br>
-                      <a href="{{statut.doc_url}}"> Voir le texte</a> 
+                      <a href="{{statut.doc_url}}"> Voir le texte</a>
                     </p>
                     {% if statut.doc_url %}
                     {% endif %}
@@ -64,7 +64,7 @@
                 <table class="table table-striped mt-3">
                   {% for syn in model.synonymes %}
                   <tr>
-                      <td class="col-5"> {{syn.nom_complet}} </td>
+                      <td class="col-5 {{'font-weight-bold' if syn.cd_nom == syn.cd_ref }}" > {{syn.nom_complet}}</td>
                       <td class="col-5"> <a href="{{url_for('taxons.details_view', id=syn.cd_nom)}}">{{syn.cd_nom}} </a>  </td>
                   </tr>
                   {% endfor %}
@@ -74,7 +74,11 @@
                     <table class="table table-striped mt-3">
                         <tr>
                             <th class="col-5"> Nom Latin</th>
-                            <td class="col-5"> {{model.lb_nom}} </th>
+                            <td class="col-5"> {{model.nom_complet}} </th>
+                        </tr>
+                        <tr>
+                            <th class="col-5"> Nom valide</th>
+                            <td class="col-5"> {{model.nom_valide}} </th>
                         </tr>
                         <tr>
                             <th class="col-5"> Nom vernaculaire</th>
@@ -113,9 +117,9 @@
                         <tr>
                             <th class="col-5"> Rang </th>
                             <td class="col-5"> {{model.rang.nom_rang}} </th>
-                        </tr>                
+                        </tr>
                     </table>
-           
+
                 </div>
 
                 <div class="tab-pane fade" id="nav-lists" role="tabpanel" aria-labelledby="nav-lists-tab">
@@ -160,9 +164,9 @@
                             <th> Auteur</th>
                             <th> Type</th>
                         </thead>
-                        {% for media in model.medias %}
+                        {% for media in medias %}
                         <tr>
-                            <td class="col-5"> 
+                            <td class="col-5">
                                 <a href="{{ url_for('t_media.getThumbnail_tmedias', id_media=media.id_media)}}">
                                     <img width="100" src="{{ url_for('t_media.getThumbnail_tmedias', id_media=media.id_media)}}"  alt="Taxon image">
                                 </a>
@@ -172,13 +176,13 @@
                             <td> {{media.auteur}} </td>
                             <td> {{media.types.nom_type_media}} </td>
                         </tr>
-          
+
                     {% endfor %}
 
                     </table>
                 </div>
 
-              </div> 
+              </div>
               <!-- END NAV CONTENT -->
 
             </div>

--- a/apptax/admin/templates/admin/edit_taxref.html
+++ b/apptax/admin/templates/admin/edit_taxref.html
@@ -11,11 +11,21 @@
 {% call lib.form_tag(action=action) %}
 
   <div class="container-fluid mt-2">
+
+
     <div class="row">
       <div class="card col-10">
         <div class="card-body">
           <h5 class="col-11 card-title"> <a href="{{url_for('taxons.details_view', id=model.cd_nom)}}" target="_blank">{{model.nom_complet}} {% if model.nom_vern %} - {{model.nom_vern}}  {% endif %} </a>  </h5>
+          
+          {% if model.cd_nom != model.cd_ref %}
+          <div class="alert alert-info" role="alert">Les attributs et les médias ne peuvent être renseignés que sur les noms valides
+            <a class="btn btn-primary" href="{{url_for('taxons.edit_view', id=model.cd_ref)}}">Voir le nom valide </a> 
+          </div>
+          {% endif %}
+
           <ul class="nav nav-tabs" id="myTab" role="tablist">
+            {% if model.cd_nom == model.cd_ref %}
             <li class="nav-item">
               <a class="nav-link active" id="home-tab" data-toggle="tab" href="#attributes" role="tab" aria-controls="home" aria-selected="true">Attributs</a>
             </li>
@@ -25,23 +35,32 @@
             <li class="nav-item">
               <a class="nav-link" id="contact-tab" data-toggle="tab" href="#medias" role="tab" aria-controls="medias" aria-selected="false">Médias</a>
             </li>
+            {% else %}
+            <li class="nav-item">
+              <a class="nav-link active" id="profile-tab" data-toggle="tab" href="#lists" role="tab" aria-controls="lists" aria-selected="true">Listes</a>
+            </li>
+            {% endif %}
           </ul>
-          <!-- LISTE -->
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade" id="lists" role="tabpanel" aria-labelledby="profile-tab">
+            <!-- LISTE -->
+            <div class="tab-pane fade {{'show active' if not model.cd_nom == model.cd_ref }}"  id="lists" role="tabpanel" aria-labelledby="profile-tab">
                 {{ lib.render_field(form, form.liste) }}
-            </div> 
-            <!-- MEDIAS -->
-            <div class="tab-pane fade" id="medias" role="tabpanel" aria-labelledby="contact-tab">
-              {{ lib.render_field(form, form.medias) }}
             </div>
+            <!-- MEDIAS -->
+            {% if model.cd_nom == model.cd_ref %}
+            <div class="tab-pane fade" id="medias" role="tabpanel" aria-labelledby="contact-tab">
+                {{ lib.render_field(form, form.medias) }}
+            </div>
+            {% endif %}
 
+            <!-- ATTRIBUTS -->
+            {% if model.cd_nom == model.cd_ref %}
             <div class="tab-pane fade show active" id="attributes" role="tabpanel" aria-labelledby="attributes-tab">
               {% for theme in theme_attributs_def %}
               <div class="card mt-2">
-                <div class="card-header"> 
+                <div class="card-header">
                   <h6>{{theme}}</h6>
-                </div> 
+                </div>
                   {% for attr in theme.attributs %}
                   <div class="form-group">
                           <label class="col-md-2 control-label" for="attr.{{attr.id_attribut}}">{{ attr.label_attribut }}</label>
@@ -86,7 +105,7 @@
                           {% else %}
                           NOT IMPLEMENTED {{ attr.type_widget }}
                           {% endif %}
-          
+
                           </div>
                         </div>
                     {% endfor %}
@@ -94,10 +113,11 @@
                     {% endfor %}
               </div>
               <!-- END ATTR TAB -->
+            {% endif %}
             </div>
 
           </div>
-          
+
           {{ lib.render_form_buttons(url_cancel) }}
 
         </div>

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -47,7 +47,7 @@ class CorTaxonAttribut(db.Model):
     )
     cd_ref = db.Column(
         db.Integer,
-        ForeignKey("taxonomie.taxref.cd_ref"),
+        ForeignKey("taxonomie.taxref.cd_nom"),
         nullable=False,
         primary_key=True,
     )
@@ -255,7 +255,7 @@ class TMedias(db.Model):
     id_media = db.Column(db.Integer, primary_key=True)
     cd_ref = db.Column(
         db.Integer,
-        ForeignKey(Taxref.cd_ref),
+        ForeignKey(Taxref.cd_nom),
         nullable=False,
         primary_key=False,
     )


### PR DESCRIPTION
Modification des modèles de taxhub.

La relation entre les  attributs et les médias  ne se fait plus sur le cd_ref mais sur le cd_nom.

Conséquence : plus possible d'ajouter des attributs et des médias sur les synonymes