### PR TITLE
Remove SQLA 1.4 warning

### DIFF
--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -45,7 +45,7 @@ class CorTaxonAttribut(db.Model):
         primary_key=True,
     )
     valeur_attribut = db.Column(db.Text, nullable=False)
-    bib_nom = db.relationship("BibNoms")
+    bib_nom = db.relationship("BibNoms", overlaps="attributs")
     bib_attribut = db.relationship("BibAttributs")
 
     def __repr__(self):
@@ -88,7 +88,7 @@ class BibAttributs(db.Model):
         primary_key=False,
     )
     ordre = db.Column(db.Integer)
-    theme = db.relationship(BibThemes)
+    theme = db.relationship(BibThemes, overlaps="attributs")
 
     def __repr__(self):
         return "<BibAttributs %r>" % self.nom_attribut
@@ -155,7 +155,7 @@ class CorNomListe(db.Model):
         nullable=False,
         primary_key=True,
     )
-    bib_nom = db.relationship("BibNoms")
+    bib_nom = db.relationship("BibNoms", overlaps="listes")
     bib_liste = db.relationship("BibListes")
 
     def __repr__(self):
@@ -174,8 +174,10 @@ class BibListes(db.Model):
     regne = db.Column(db.Unicode)
     group2_inpn = db.Column(db.Unicode)
 
-    cnl = db.relationship("CorNomListe", lazy="select")
-    noms = db.relationship("BibNoms", secondary=CorNomListe.__table__)
+    cnl = db.relationship("CorNomListe", lazy="select", overlaps="bib_liste")
+    noms = db.relationship(
+        "BibNoms", secondary=CorNomListe.__table__, overlaps="bib_nom,bib_liste,listes,cnl"
+    )
 
     def __repr__(self):
         return "<BibListes %r>" % self.nom_liste
@@ -372,7 +374,7 @@ class TaxrefBdcStatutText(db.Model):
     doc_url = db.Column(db.Unicode)
     enable = db.Column(db.Boolean)
 
-    type_statut = db.relationship("TaxrefBdcStatutType", lazy="select")
+    type_statut = db.relationship("TaxrefBdcStatutType", lazy="select", overlaps="text")
     cor_text = db.relationship("TaxrefBdcStatutCorTextValues", lazy="select")
 
     areas = db.relationship(LAreas, secondary=bdc_statut_cor_text_area)
@@ -403,7 +405,7 @@ class TaxrefBdcStatutCorTextValues(db.Model):
         db.Unicode, ForeignKey("taxonomie.bdc_statut_text.id_text"), nullable=False
     )
 
-    text = db.relationship("TaxrefBdcStatutText", lazy="select")
+    text = db.relationship("TaxrefBdcStatutText", lazy="select", overlaps="cor_text")
     value = db.relationship("TaxrefBdcStatutValues", lazy="select")
 
     taxon = db.relationship("TaxrefBdcStatutTaxon", lazy="select")
@@ -423,7 +425,7 @@ class TaxrefBdcStatutTaxon(db.Model):
     cd_ref = db.Column(db.Integer)
     rq_statut = db.Column(db.Unicode)
 
-    value_text = db.relationship("TaxrefBdcStatutCorTextValues", lazy="select")
+    value_text = db.relationship("TaxrefBdcStatutCorTextValues", lazy="select", overlaps="taxon")
 
 
 @serializable

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -27,6 +27,9 @@ class BibNoms(db.Model):
     listes = db.relationship("CorNomListe", back_populates="bib_nom")
     # medias relationship defined through backref
 
+    def __repr__(self):
+        return f"<BibNoms {self.nom_francais}>"
+
 
 @serializable
 class CorTaxonAttribut(db.Model):
@@ -49,7 +52,7 @@ class CorTaxonAttribut(db.Model):
     bib_attribut = db.relationship("BibAttributs")
 
     def __repr__(self):
-        return "<CorTaxonAttribut %r>" % self.valeur_attribut
+        return f"<CorTaxonAttribut {self.valeur_attribut}>"
 
 
 @serializable
@@ -64,7 +67,7 @@ class BibThemes(db.Model):
     attributs = db.relationship("BibAttributs", lazy="select", back_populates="theme")
 
     def __repr__(self):
-        return "<BibThemes %r>" % self.nom_theme
+        return f"<BibThemes {self.nom_theme}>"
 
 
 @serializable
@@ -91,7 +94,7 @@ class BibAttributs(db.Model):
     theme = db.relationship(BibThemes, back_populates="attributs")
 
     def __repr__(self):
-        return "<BibAttributs %r>" % self.nom_attribut
+        return f"<BibAttributs {self.nom_attribut}>"
 
 
 @serializable(exclude=["nom_vern_or_lb_nom"])
@@ -125,7 +128,7 @@ class Taxref(db.Model):
     group3_inpn = db.Column(db.Unicode)
     url = db.Column(db.Unicode)
 
-    bib_nom = db.relationship("BibNoms", back_populates="taxref")
+    bib_nom = db.relationship(BibNoms, back_populates="taxref")
 
     @hybrid_property
     def nom_vern_or_lb_nom(self):
@@ -136,7 +139,7 @@ class Taxref(db.Model):
         return db.func.coalesce(cls.nom_vern, cls.lb_nom)
 
     def __repr__(self):
-        return "<Taxref %r>" % self.nom_complet
+        return f"<Taxref {self.nom_complet}>"
 
 
 @serializable
@@ -155,11 +158,11 @@ class CorNomListe(db.Model):
         nullable=False,
         primary_key=True,
     )
-    bib_nom = db.relationship("BibNoms", back_populates="listes")
+    bib_nom = db.relationship(BibNoms, back_populates="listes")
     bib_liste = db.relationship("BibListes", back_populates="cnl")
 
     def __repr__(self):
-        return "<CorNomListe %r>" % self.id_liste
+        return f"<CorNomListe {self.id_liste}>"
 
 
 @serializable
@@ -174,13 +177,13 @@ class BibListes(db.Model):
     regne = db.Column(db.Unicode)
     group2_inpn = db.Column(db.Unicode)
 
-    cnl = db.relationship("CorNomListe", lazy="select", back_populates="bib_liste")
+    cnl = db.relationship(CorNomListe, lazy="select", back_populates="bib_liste")
     noms = db.relationship(
         "BibNoms", secondary=CorNomListe.__table__, overlaps="bib_nom,listes,bib_liste,cnl"
     )
 
     def __repr__(self):
-        return "<BibListes %r>" % self.nom_liste
+        return f"<BibListes {self.nom_liste}>"
 
 
 @serializable
@@ -192,7 +195,7 @@ class BibTypesMedia(db.Model):
     desc_type_media = db.Column(db.Text)
 
     def __repr__(self):
-        return "<BibTypesMedia %r>" % self.nom_type_media
+        return f"<BibTypesMedia {self.nom_type_media}>"
 
 
 @serializable
@@ -225,7 +228,7 @@ class TMedias(db.Model):
     bib_nom = db.relationship(BibNoms, backref="medias")
 
     def __repr__(self):
-        return "<TMedias %r>" % self.titre
+        return f"<TMedias {self.titre}>"
 
 
 @serializable
@@ -245,7 +248,7 @@ class VMTaxrefListForautocomplete(db.Model):
     group3_inpn = db.Column(db.Unicode)
 
     def __repr__(self):
-        return "<VMTaxrefListForautocomplete  %r>" % self.search_name
+        return f"<VMTaxrefListForautocomplete {self.search_name} >"
 
 
 @serializable
@@ -257,7 +260,7 @@ class BibTaxrefHabitats(db.Model):
     desc_habitat = db.Column(db.Text)
 
     def __repr__(self):
-        return "<BibTaxrefHabitats %r>" % self.nom_habitat
+        return f"<BibTaxrefHabitats {self.nom_habitat}>"
 
 
 @serializable
@@ -269,7 +272,7 @@ class BibTaxrefRangs(db.Model):
     tri_rang = db.Column(db.Integer)
 
     def __repr__(self):
-        return "<BibTaxrefRangs %r>" % self.nom_rang
+        return f"<BibTaxrefRangs {self.nom_rang}>"
 
 
 @serializable
@@ -280,7 +283,7 @@ class BibTaxrefStatus(db.Model):
     nom_statut = db.Column(db.Unicode)
 
     def __repr__(self):
-        return "<BibTaxrefStatus %r>" % self.nom_statut
+        return f"<BibTaxrefStatus {self.nom_statut}>"
 
 
 @serializable
@@ -303,7 +306,7 @@ class VMTaxrefHierarchie(db.Model):
     nb_tx_kd = db.Column(db.Integer)
 
     def __repr__(self):
-        return "<VMTaxrefHierarchie %r>" % self.lb_nom
+        return f"<VMTaxrefHierarchie {self.lb_nom}>"
 
 
 @serializable
@@ -325,7 +328,7 @@ class VTaxrefHierarchieBibtaxons(db.Model):
     nb_tx_kd = db.Column(db.Integer)
 
     def __repr__(self):
-        return "<VMTaxrefHierarchie %r>" % self.lb_nom
+        return f"<VMTaxrefHierarchie {self.lb_nom}>"
 
 
 @serializable
@@ -374,7 +377,7 @@ class TaxrefBdcStatutText(db.Model):
     doc_url = db.Column(db.Unicode)
     enable = db.Column(db.Boolean)
 
-    type_statut = db.relationship("TaxrefBdcStatutType", lazy="select", back_populates="text")
+    type_statut = db.relationship(TaxrefBdcStatutType, lazy="select", back_populates="text")
     cor_text = db.relationship(
         "TaxrefBdcStatutCorTextValues", lazy="select", back_populates="text"
     )
@@ -407,8 +410,8 @@ class TaxrefBdcStatutCorTextValues(db.Model):
         db.Unicode, ForeignKey("taxonomie.bdc_statut_text.id_text"), nullable=False
     )
 
-    text = db.relationship("TaxrefBdcStatutText", lazy="select", back_populates="cor_text")
-    value = db.relationship("TaxrefBdcStatutValues", lazy="select")
+    text = db.relationship(TaxrefBdcStatutText, lazy="select", back_populates="cor_text")
+    value = db.relationship(TaxrefBdcStatutValues, lazy="select")
 
     taxon = db.relationship("TaxrefBdcStatutTaxon", lazy="select", back_populates="value_text")
 
@@ -428,7 +431,7 @@ class TaxrefBdcStatutTaxon(db.Model):
     rq_statut = db.Column(db.Unicode)
 
     value_text = db.relationship(
-        "TaxrefBdcStatutCorTextValues", lazy="select", back_populates="taxon"
+        TaxrefBdcStatutCorTextValues, lazy="select", back_populates="taxon"
     )
 
 

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -23,8 +23,8 @@ class BibNoms(db.Model):
     comments = db.Column(db.Unicode)
 
     taxref = db.relationship("Taxref", back_populates="bib_nom")
-    attributs = db.relationship("CorTaxonAttribut")
-    listes = db.relationship("CorNomListe")
+    attributs = db.relationship("CorTaxonAttribut", back_populates="bib_nom")
+    listes = db.relationship("CorNomListe", back_populates="bib_nom")
     # medias relationship defined through backref
 
 
@@ -45,7 +45,7 @@ class CorTaxonAttribut(db.Model):
         primary_key=True,
     )
     valeur_attribut = db.Column(db.Text, nullable=False)
-    bib_nom = db.relationship("BibNoms", overlaps="attributs")
+    bib_nom = db.relationship("BibNoms", back_populates="attributs")
     bib_attribut = db.relationship("BibAttributs")
 
     def __repr__(self):
@@ -61,7 +61,7 @@ class BibThemes(db.Model):
     desc_theme = db.Column(db.Unicode)
     ordre = db.Column(db.Integer)
     id_droit = db.Column(db.Integer)
-    attributs = db.relationship("BibAttributs", lazy="select")
+    attributs = db.relationship("BibAttributs", lazy="select", back_populates="theme")
 
     def __repr__(self):
         return "<BibThemes %r>" % self.nom_theme
@@ -88,7 +88,7 @@ class BibAttributs(db.Model):
         primary_key=False,
     )
     ordre = db.Column(db.Integer)
-    theme = db.relationship(BibThemes, overlaps="attributs")
+    theme = db.relationship(BibThemes, back_populates="attributs")
 
     def __repr__(self):
         return "<BibAttributs %r>" % self.nom_attribut
@@ -155,8 +155,8 @@ class CorNomListe(db.Model):
         nullable=False,
         primary_key=True,
     )
-    bib_nom = db.relationship("BibNoms", overlaps="listes")
-    bib_liste = db.relationship("BibListes")
+    bib_nom = db.relationship("BibNoms", back_populates="listes")
+    bib_liste = db.relationship("BibListes", back_populates="cnl")
 
     def __repr__(self):
         return "<CorNomListe %r>" % self.id_liste
@@ -174,9 +174,9 @@ class BibListes(db.Model):
     regne = db.Column(db.Unicode)
     group2_inpn = db.Column(db.Unicode)
 
-    cnl = db.relationship("CorNomListe", lazy="select", overlaps="bib_liste")
+    cnl = db.relationship("CorNomListe", lazy="select", back_populates="bib_liste")
     noms = db.relationship(
-        "BibNoms", secondary=CorNomListe.__table__, overlaps="bib_nom,bib_liste,listes,cnl"
+        "BibNoms", secondary=CorNomListe.__table__, overlaps="bib_nom,listes,bib_liste,cnl"
     )
 
     def __repr__(self):
@@ -338,7 +338,7 @@ class TaxrefBdcStatutType(db.Model):
     thematique = db.Column(db.Unicode)
     type_value = db.Column(db.Unicode)
 
-    text = db.relationship("TaxrefBdcStatutText", lazy="select")
+    text = db.relationship("TaxrefBdcStatutText", lazy="select", back_populates="type_statut")
 
     @hybrid_property
     def display(self):
@@ -374,8 +374,10 @@ class TaxrefBdcStatutText(db.Model):
     doc_url = db.Column(db.Unicode)
     enable = db.Column(db.Boolean)
 
-    type_statut = db.relationship("TaxrefBdcStatutType", lazy="select", overlaps="text")
-    cor_text = db.relationship("TaxrefBdcStatutCorTextValues", lazy="select")
+    type_statut = db.relationship("TaxrefBdcStatutType", lazy="select", back_populates="text")
+    cor_text = db.relationship(
+        "TaxrefBdcStatutCorTextValues", lazy="select", back_populates="text"
+    )
 
     areas = db.relationship(LAreas, secondary=bdc_statut_cor_text_area)
 
@@ -405,10 +407,10 @@ class TaxrefBdcStatutCorTextValues(db.Model):
         db.Unicode, ForeignKey("taxonomie.bdc_statut_text.id_text"), nullable=False
     )
 
-    text = db.relationship("TaxrefBdcStatutText", lazy="select", overlaps="cor_text")
+    text = db.relationship("TaxrefBdcStatutText", lazy="select", back_populates="cor_text")
     value = db.relationship("TaxrefBdcStatutValues", lazy="select")
 
-    taxon = db.relationship("TaxrefBdcStatutTaxon", lazy="select")
+    taxon = db.relationship("TaxrefBdcStatutTaxon", lazy="select", back_populates="value_text")
 
 
 @serializable
@@ -425,7 +427,9 @@ class TaxrefBdcStatutTaxon(db.Model):
     cd_ref = db.Column(db.Integer)
     rq_statut = db.Column(db.Unicode)
 
-    value_text = db.relationship("TaxrefBdcStatutCorTextValues", lazy="select", overlaps="taxon")
+    value_text = db.relationship(
+        "TaxrefBdcStatutCorTextValues", lazy="select", back_populates="taxon"
+    )
 
 
 @serializable


### PR DESCRIPTION
Cette PR a pour objectif de supprimer les warnings provoqués par SQLAlchemy en vue de la mise à jour vers la version 1.4/2.0.