### PR TITLE
feat(sentry): add stage with `sentry_sdk[flask]` to dockerfile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,6 @@ setuptools.setup(
             "pytest-cov",
             "schema",
         ],
+        "sentry": ["sentry_sdk[flask]"],
     },
 )


### PR DESCRIPTION
⚠️ The main purpose of this PR is to make Sentry connection possible in the context of a deployment with Docker, using such a Compose file : https://github.com/PnX-SI/GeoNature-Docker-services/blob/main/docker-compose.yml

# DESCRIPTION

The Python library `sentry_sdk[flask]` can be used to add a connection between the Flask application and a Sentry project by adding relevant lines in the `config.py` file.

See this docs for more information : https://docs.sentry.io/platforms/python/integrations/flask/#install