### PR TITLE
#332 fixes nom vern list in vm autocomplete

### DIFF
--- a/apptax/migrations/versions/0db13d65cb27_fix_nom_vern_vm_autocomplete.py
+++ b/apptax/migrations/versions/0db13d65cb27_fix_nom_vern_vm_autocomplete.py
@@ -1,0 +1,121 @@
+"""fix nom_vern in vm_taxref_list_forautocomplete
+
+Revision ID: 0db13d65cb27
+Revises: 8f3256f60915
+Create Date: 2023-09-06 06:49:50.248414
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0db13d65cb27"
+down_revision = "8f3256f60915"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+            -- taxonomie.vm_taxref_list_forautocomplete source
+
+            DROP MATERIALIZED VIEW IF EXISTS taxonomie.vm_taxref_list_forautocomplete;
+
+            CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete
+            TABLESPACE pg_default
+            AS SELECT row_number() OVER () AS gid,
+                t.cd_nom,
+                t.cd_ref,
+                t.search_name,
+                unaccent(t.search_name) AS unaccent_search_name,
+                t.nom_valide,
+                t.lb_nom,
+                t.nom_vern,
+                t.regne,
+                t.group2_inpn,
+                t.group3_inpn
+            FROM ( SELECT t_1.cd_nom,
+                        t_1.cd_ref,
+                        concat(t_1.lb_nom, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_nom, ']') AS search_name,
+                        t_1.nom_valide,
+                        t_1.lb_nom,
+                        t_1.nom_vern,
+                        t_1.regne,
+                        t_1.group2_inpn,
+                        t_1.group3_inpn
+                    FROM taxonomie.taxref t_1
+                    UNION
+                    SELECT DISTINCT t_1.cd_nom,
+                        t_1.cd_ref,
+                        concat(t_1.nom_vern::text, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_ref, ']') AS search_name,
+                        t_1.nom_valide,
+                        t_1.lb_nom,
+                        t_1.nom_vern,
+                        t_1.regne,
+                        t_1.group2_inpn,
+                        t_1.group3_inpn
+                    FROM taxonomie.taxref t_1
+                    WHERE t_1.nom_vern IS NOT NULL AND t_1.cd_nom = t_1.cd_ref) t
+            WITH DATA;
+
+            -- View indexes:
+            CREATE INDEX i_tri_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete USING gin (unaccent_search_name gin_trgm_ops);
+            CREATE INDEX i_vm_taxref_list_forautocomplete_cd_nom ON taxonomie.vm_taxref_list_forautocomplete USING btree (cd_nom);
+            CREATE UNIQUE INDEX i_vm_taxref_list_forautocomplete_gid ON taxonomie.vm_taxref_list_forautocomplete USING btree (gid);
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+            -- taxonomie.vm_taxref_list_forautocomplete source
+
+            DROP MATERIALIZED VIEW IF EXISTS taxonomie.vm_taxref_list_forautocomplete;
+
+            CREATE MATERIALIZED VIEW taxonomie.vm_taxref_list_forautocomplete
+            TABLESPACE pg_default
+            AS SELECT row_number() OVER () AS gid,
+                t.cd_nom,
+                t.cd_ref,
+                t.search_name,
+                unaccent(t.search_name) AS unaccent_search_name,
+                t.nom_valide,
+                t.lb_nom,
+                t.nom_vern,
+                t.regne,
+                t.group2_inpn,
+                t.group3_inpn
+            FROM ( SELECT t_1.cd_nom,
+                        t_1.cd_ref,
+                        concat(t_1.lb_nom, ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_nom, ']') AS search_name,
+                        t_1.nom_valide,
+                        t_1.lb_nom,
+                        t_1.nom_vern,
+                        t_1.regne,
+                        t_1.group2_inpn,
+                        t_1.group3_inpn
+                    FROM taxonomie.taxref t_1
+                    UNION
+                    SELECT DISTINCT t_1.cd_nom,
+                        t_1.cd_ref,
+                        concat(split_part(t_1.nom_vern, ',', 1), ' = <i>', t_1.nom_valide, '</i>', ' - [', t_1.id_rang, ' - ', t_1.cd_ref, ']') AS search_name,
+                        t_1.nom_valide,
+                        t_1.lb_nom,
+                        t_1.nom_vern,
+                        t_1.regne,
+                        t_1.group2_inpn,
+                        t_1.group3_inpn
+                    FROM taxonomie.taxref t_1
+                    WHERE t_1.nom_vern IS NOT NULL AND t_1.cd_nom = t_1.cd_ref) t
+            WITH DATA;
+
+            -- View indexes:
+            CREATE INDEX i_tri_vm_taxref_list_forautocomplete_search_name ON taxonomie.vm_taxref_list_forautocomplete USING gin (unaccent_search_name gin_trgm_ops);
+            CREATE INDEX i_vm_taxref_list_forautocomplete_cd_nom ON taxonomie.vm_taxref_list_forautocomplete USING btree (cd_nom);
+            CREATE UNIQUE INDEX i_vm_taxref_list_forautocomplete_gid ON taxonomie.vm_taxref_list_forautocomplete USING btree (gid);
+        """
+    )


### PR DESCRIPTION
Bonjour,

Dans le cadre d'une prestation avec l'ARB IDF , il a été remonté le problème de recherche de taxons sur plusieurs noms vernaculaire avec le retour à la ligne. 
La PR concernée et qui date de 2023 était celle ci : https://github.com/PnX-SI/TaxHub/pull/435 (réalisée par @JulienCorny)
Il y a bien eu par contre la partie frontend qui a été acceptée et mergée pour le retour à la ligne : https://github.com/PnX-SI/GeoNature/pull/2690 .

L'issue liée à ces deux PR est la suivante : https://github.com/PnX-SI/TaxHub/issues/332

J'ai ouvert cette PR pour repartir des branches develop de GeoNature et TaxHub mais aussi car nous centralisos maintenant les PR en tant qu'organisation Natural Solutions et non plus créées chacun de son coté .

Si cette PR est accepté alors l'issue et la PR suivantes pourront être cloturées :
- https://github.com/PnX-SI/TaxHub/pull/435 
- https://github.com/PnX-SI/TaxHub/issues/332

Merci pour vos retours ! 

Exemple des différences sur une recherche d'espèce avec comme texte "Robert le diable"  : 

- Comportement actuel (test sur la démo) : 
![image](https://github.com/user-attachments/assets/103ee722-cb69-4f4e-ba6d-3cbbb0a743ae)

- Comportement avec les développements proposés : 
![image](https://github.com/user-attachments/assets/26843c45-0999-42c4-88f7-25ffac99e239)
