### PR TITLE
feat: add route that serve status symbology

### DIFF
--- a/apptax/taxonomie/routesbdcstatuts.py
+++ b/apptax/taxonomie/routesbdcstatuts.py
@@ -81,6 +81,61 @@ def get_status_lists_values(status_type=None):
     return [d.as_dict(fields=("code_statut", "label_statut", "display")) for d in data]
 
 
+@adresses.route("/status_symbologies", methods=["GET"])
+def get_status_symbologies():
+    """
+    Retourne un json décrivant la symbologie associée aux valeurs de statuts.
+
+    :returns: un json de la structure suivante
+    {
+        symbologies: [
+            {
+                types: ["Type 1", "<Type 2>", etc.],
+                values: {
+                    [value]: {
+                        color: "color"
+                    }
+                }
+            },
+            ...
+            {
+                types: ["LRM", "LRE", "LRN", "LRR"],
+                values: {
+                    LC: {
+                        color: "#78b74a"
+                    },
+                    VU: {
+                        color: "#ffed00"
+                    }
+                }
+            }
+        ]
+    }
+    """
+    return jsonify(
+        {
+            "symbologies": [
+                {
+                    "types": ["LRM", "LRE", "LRN", "LRR"],
+                    "values": {
+                        "EX": {"color": "#000000"},
+                        "EW": {"color": "#3d1951"},
+                        "RE": {"color": "#5a1a63"},
+                        "CR": {"color": "#d3001b"},
+                        "EN": {"color": "#fbbf00"},
+                        "VU": {"color": "#ffed00"},
+                        "NT": {"color": "#fbf2ca"},
+                        "LC": {"color": "#78b74a"},
+                        "DD": {"color": "#d3d4d5"},
+                        "NA": {"color": "#919291"},
+                        "NE": {"color": "#ffffff"},
+                    },
+                }
+            ]
+        }
+    )
+
+
 @adresses.route("/status_types", methods=["GET"])
 @json_resp
 def get_status_types():

--- a/apptax/tests/test_bdcstatus.py
+++ b/apptax/tests/test_bdcstatus.py
@@ -1,0 +1,33 @@
+import pytest
+from flask import url_for
+
+DEFAULT_STATUS_SYMBOLOGY = {
+    "symbologies": [
+        {
+            "types": ["LRM", "LRE", "LRN", "LRR"],
+            "values": {
+                "EX": {"color": "#000000"},
+                "EW": {"color": "#3d1951"},
+                "RE": {"color": "#5a1a63"},
+                "CR": {"color": "#d3001b"},
+                "EN": {"color": "#fbbf00"},
+                "VU": {"color": "#ffed00"},
+                "NT": {"color": "#fbf2ca"},
+                "LC": {"color": "#78b74a"},
+                "DD": {"color": "#d3d4d5"},
+                "NA": {"color": "#919291"},
+                "NE": {"color": "#ffffff"},
+            },
+        }
+    ]
+}
+
+
+@pytest.mark.usefixtures("client_class")
+class TestApiBdcStatus:
+    def test_status_symbologies(self):
+        response = self.client.get(
+            url_for("bdc_status.get_status_symbologies"),
+        )
+        assert response.status_code == 200
+        assert response.json == DEFAULT_STATUS_SYMBOLOGY

--- a/docs/developpement.md
+++ b/docs/developpement.md
@@ -20,9 +20,9 @@
 
 - `/taxref/{cd_nom}`: Retourne un enregistrement de la table `taxonomie.taxref` avec les synonymes et statuts associés
     - Méthode autorisée : GET
-                           
+
 - `/taxref/allnamebylist/<int(signed=True):id_liste>` : Retourne les données de la vue matérialisée `vm_taxreflist_for_autocomplete`
-    - Paramètres : 
+    - Paramètres :
         - id_liste : identifiant de la liste (si id_liste est null ou égal à -1 on ne filtre pas sur une liste)
     params GET (facultatifs):
         - code_liste : code de la liste à filtrer, n'est pris en compte que si aucune liste n'est spécifiée
@@ -32,7 +32,7 @@
         - limit : nombre de résultats
         - offset : numéro de la page
 
-- `/taxref/bib_habitats` : Retourne la liste des habitats définis dans Taxref                   
+- `/taxref/bib_habitats` : Retourne la liste des habitats définis dans Taxref
 - `/taxref/groupe3_inpn` : Retourne la liste des groupes 3 définis dans Taxref
 - `/taxref/regnewithgroupe2` : Retourne une liste hiérarchisée des règnes avec les groupes 2 associés
 
@@ -42,7 +42,7 @@
 - `/biblistes/<regne>` : retourne les listes filtrées par règne
 - `/biblistes/<regne>/<group2_inpn>` : retourne les listes filtrées par groupe 2 INPN
 
-## BDC statuts 
+## BDC statuts
 
 - `/bdc_statuts/list/<int(signed=True):cd_ref>` : Retourne la liste des statuts associés à un taxon.
 - `/bdc_statuts/hierarchy/<int(signed=True):cd_ref>` : Retourne la liste des statuts associés sous forme hiérarchique.
@@ -51,3 +51,31 @@
     - Params :
         -   codes : filtre sur une liste de codes de types de statuts séparés par des virgules.
         -   gatherings : filtre sur une liste de type de regroupement de types de statuts séparés par des virgules.
+- `/bdc_statuts/status_symbologies`  : Retourne les symbologies associées au statuts au format JSON. \
+  Ces symbologies sont définies statiquement, au format suivant:\
+
+```json
+{
+    "symbologies": [
+        {
+            "types": ["LRM", "LRE", "LRN", "LRR"],
+            "values": {
+                "EX": {"color": "#000000"},
+                "EW": {"color": "#3d1951"},
+                "RE": {"color": "#5a1a63"},
+                "CR": {"color": "#d3001b"},
+                "EN": {"color": "#fbbf00"},
+                "VU": {"color": "#ffed00"},
+                "NT": {"color": "#fbf2ca"},
+                "LC": {"color": "#78b74a"},
+                "DD": {"color": "#d3d4d5"},
+                "NA": {"color": "#919291"},
+                "NE": {"color": "#ffffff"},
+            },
+        }
+    ]
+}
+```
+
+> Ces valeurs sont issues de la charte des codes couleurs pour les statuts Liste rouge, définis internationalement par l'Union internationale pour la conservation de la nature (UICN) \
+> <https://uicn.fr/wp-content/uploads/2018/04/guide-pratique-listes-rouges-regionales-especes-menacees.pdf> (page 55)


### PR DESCRIPTION
Il s'agit du fix proposé dans l'issue GeoNature [#3187](https://github.com/PnX-SI/GeoNature/issues/3187)

https://github.com/PnX-SI/GeoNature/issues/3187#issuecomment-2368515644

Le principe est de servir la symbologie des statut au format json.

A terme, ce contenu sera intégré à la future route "status"
