### PR TITLE
Load types medias from taxref route and bib_attributs related attributs 

### DIFF
--- a/apptax/taxonomie/routestaxref.py
+++ b/apptax/taxonomie/routestaxref.py
@@ -16,6 +16,7 @@ from apptax.taxonomie.models import (
     BibListes,
     TMetaTaxref,
     CorTaxonAttribut,
+    TMedias,
 )
 
 from .repositories import BdcStatusRepository
@@ -212,6 +213,7 @@ def getTaxrefDetail(id):
             "attributs",
             "listes",
             "medias",
+            "medias.types",
             "status",
             "synonymes.cd_nom",
             "synonymes.nom_complet",
@@ -226,6 +228,9 @@ def getTaxrefDetail(id):
     fields = [f for f in fields if not f.split(".")[0] == "status"]
 
     joinedload_when_attributs = get_joinedload_when_attributs(fields=fields)
+    if "medias" in firstlevel_fields:
+        joinedload_when_attributs.append(joinedload(Taxref.medias).joinedload(TMedias.types))
+
     query = (
         Taxref.joined_load(join_relationship)
         .options(*joinedload_when_attributs)


### PR DESCRIPTION
Cette PR propose de palier au besoin de récupération des informations du "type" de média associés aux taxons. Il propose également de remonter les informations liés à bib_attributs (informations qui pourrait être utiles également pour certains besoins dont GN Citizen). 

Pour remonter ces informations liées aux taxons d'une liste avec comme id_liste = 101 par exemple voici la route à appeler : `/taxref?id_liste=101&fields=medias.types,attributs.bib_attribut`

Le développement proposé ici propose une modifications des jointures réalisées sur la base de ce que l'on passe en query params et permet de garder la souplesse du code actuel afin de ne pas les charger systématiquement.


<details><summary> Partie de Réponse à l'appel de la route "/taxref?id_liste=101&fields=medias.types,attributs,attributs.bib_attribut" </summary>

```json
....
 {
      "attributs": [
        {
          "bib_attribut": {
            "desc_attribut": "Test attribut",
            "group2_inpn": null,
            "id_attribut": 105,
            "id_theme": 1,
            "label_attribut": "nom_fran\u00e7ais",
            "liste_valeur_attribut": null,
            "nom_attribut": "nom_fran\u00e7ais",
            "obligatoire": false,
            "ordre": null,
            "regne": null,
            "type_attribut": "text ",
            "type_widget": "text"
          },
          "cd_ref": 534742,
          "id_attribut": 105,
          "valeur_attribut": "M\u00e9sange bleue"
        }
      ],
      "cd_nom": 534742,
      "cd_ref": 534742,
      "cd_sup": 836858,
      "cd_taxsup": 836858,
      "classe": "Aves",
      "famille": "Paridae",
      "group1_inpn": "Chord\u00e9s",
      "group2_inpn": "Oiseaux",
      "group3_inpn": "Autres",
      "id_habitat": 3,
      "id_rang": "ES",
      "id_statut": "P",
      "lb_auteur": "(Linnaeus, 1758)",
      "lb_nom": "Cyanistes caeruleus",
      "medias": [
        {
          "auteur": null,
          "cd_ref": 534742,
          "chemin": "534742_mesange_bleue-4967.jpg",
          "desc_media": "",
          "id_media": 4,
          "id_type": 1,
          "is_public": true,
          "licence": null,
          "media_url": "http://127.0.0.1:5000/home/andriac/applications/dev/gn-citizen-dev/taxhub/apptax/media/taxhub/534742_mesange_bleue-4967.jpg",
          "source": null,
          "titre": "M\u00e9sange bleu",
          "types": {
            "desc_type_media": "Photo principale du taxon \u00e0 utiliser pour les vignettes par exemple",
            "id_type": 1,
            "nom_type_media": "Photo_principale"
          },
          "url": null
        }
      ],
      "nom_complet": "Cyanistes caeruleus (Linnaeus, 1758)",
      "nom_complet_html": "<i>Cyanistes caeruleus</i> (Linnaeus, 1758)",
      "nom_valide": "Cyanistes caeruleus (Linnaeus, 1758)",
      "nom_vern": "M\u00e9sange bleue",
      "nom_vern_eng": null,
      "ordre": "Passeriformes",
      "phylum": "Chordata",
      "regne": "Animalia",
      "sous_famille": null,
      "tribu": null,
      "url": "https://inpn.mnhn.fr/espece/cd_nom/534742"
    }
    ...
```

</details>

Voir issue :  #582  