### PR TITLE
feat(media): allow thumbnail generation with only the width parameter

### DIFF
--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -101,6 +101,9 @@ class LocalFileManagerService:
         # If width only was given in the parameter (height <=> size[1] < 0)
         if size[1] < 0:
             size[1] = img.width / size[0] * img.height
+        # Same with height
+        if size[0] < 0:
+            size[0] = img.height / size[1] * img.width
 
         # Création du thumbnail
         resizeImg = resize_thumbnail(img, (size[0], size[1], force))

--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -94,9 +94,13 @@ class LocalFileManagerService:
 
         # Get Image
         try:
-            img = self._get_image_object(media)
+            img: Image = self._get_image_object(media)
         except TaxhubError as e:
             return None
+
+        # If width only was given in the parameter (height <=> size[1] < 0)
+        if size[1] < 0:
+            size[1] = img.width / size[0] * img.height
 
         # Création du thumbnail
         resizeImg = resize_thumbnail(img, (size[0], size[1], force))

--- a/apptax/taxonomie/routestmedias.py
+++ b/apptax/taxonomie/routestmedias.py
@@ -94,8 +94,8 @@ def getThumbnail_tmedias(id_media):
     if width_params and width_params.isdigit():
         size = (int(width_params), size[1])
 
-        if height_params and height_params.isdigit():
-            size = (size[0], int(height_params))
+    if height_params and height_params.isdigit():
+        size = (size[0], int(height_params))
 
     force = False
     if ("force" in params) and (params.get("force") == "true"):

--- a/apptax/taxonomie/routestmedias.py
+++ b/apptax/taxonomie/routestmedias.py
@@ -88,8 +88,8 @@ def getThumbnail_tmedias(id_media):
 
     size = DEFAULT_THUMBNAIL_SIZE
 
-    height_params: str = params.get("h", "-1")
-    width_params: str = params.get("w", "-1")
+    height_params: str = params.get("h", None)
+    width_params: str = params.get("w", None)
 
     if width_params and width_params.isdigit():
         size = (int(width_params), size[1])

--- a/apptax/taxonomie/routestmedias.py
+++ b/apptax/taxonomie/routestmedias.py
@@ -10,6 +10,7 @@ from .schemas import TMediasSchema, BibTypesMediaSchema
 
 from .filemanager import FILEMANAGER
 
+DEFAULT_THUMBNAIL_SIZE = (300, 400)
 
 adresses = Blueprint("t_media", __name__)
 logger = logging.getLogger()
@@ -84,9 +85,17 @@ def getThumbnail_tmedias(id_media):
         )
 
     params = request.args
-    size = (300, 400)
-    if ("h" in params) or ("w" in params):
-        size = (int(params.get("h", -1)), int(params.get("w", -1)))
+
+    size = DEFAULT_THUMBNAIL_SIZE
+
+    height_params: str = params.get("h", "-1")
+    width_params: str = params.get("w", "-1")
+
+    if width_params and width_params.isdigit():
+        size = (int(width_params), size[1])
+
+        if height_params and height_params.isdigit():
+            size = (size[0], int(height_params))
 
     force = False
     if ("force" in params) and (params.get("force") == "true"):

--- a/apptax/taxonomie/routestmedias.py
+++ b/apptax/taxonomie/routestmedias.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import os
 from flask import json, Blueprint, request, current_app, send_file, abort
+from werkzeug.exceptions import Forbidden
 
 
 from .models import TMedias, BibTypesMedia
@@ -91,10 +92,15 @@ def getThumbnail_tmedias(id_media):
     height_params: str = params.get("h", None)
     width_params: str = params.get("w", None)
 
-    if width_params and width_params.isdigit():
+    if (width_params and not width_params.isdigit()) or (
+        height_params and not height_params.isdigit()
+    ):
+        raise Forbidden("Valeur de la hauteur ou largeur incorrecte: Un entier est attendu")
+
+    if width_params:
         size = (int(width_params), size[1])
 
-    if height_params and height_params.isdigit():
+    if height_params:
         size = (size[0], int(height_params))
 
     force = False

--- a/apptax/tests/test_media.py
+++ b/apptax/tests/test_media.py
@@ -122,3 +122,18 @@ class TestAPIMedia:
             url_for("t_media.getThumbnail_tmedias", id_media=id_media),
         )
         assert response.status_code == 200
+
+        response = self.client.get(
+            url_for("t_media.getThumbnail_tmedias", id_media=id_media, w=200, h=200),
+        )
+        assert response.status_code == 200
+
+        response = self.client.get(
+            url_for("t_media.getThumbnail_tmedias", id_media=id_media, w=200),
+        )
+        assert response.status_code == 200
+
+        response = self.client.get(
+            url_for("t_media.getThumbnail_tmedias", id_media=id_media, h=200),
+        )
+        assert response.status_code == 200

--- a/apptax/tests/test_media.py
+++ b/apptax/tests/test_media.py
@@ -3,7 +3,7 @@ import os
 
 from apptax.taxonomie.models import BibTypesMedia, TMedias
 import pytest
-from flask import url_for, current_app
+from flask import url_for, current_app, Response
 
 from apptax.database import db
 
@@ -133,25 +133,22 @@ class TestAPIMedia:
     #     id_media = json.loads(response.data)["id_media"]
     #     self.get_thumbnail(id_media)
 
-    def test_get_thumbnail(self, media):
+    @pytest.mark.parametrize(
+        "get_params,expected_status_code",
+        [
+            ({}, 200),
+            (dict(w=100), 200),
+            (dict(h=100), 200),
+            (dict(w=100, h=100), 200),
+            (dict(w="a", h="b"), 403),
+            (dict(h="b"), 403),
+        ],
+    )
+    def test_get_thumbnail(self, media, get_params, expected_status_code):
         id_media = media.id_media
 
-        response = self.client.get(
-            url_for("t_media.getThumbnail_tmedias", id_media=id_media),
+        response: Response = self.client.get(
+            url_for("t_media.getThumbnail_tmedias", id_media=id_media, **get_params),
         )
-        assert response.status_code == 200
-
-        response = self.client.get(
-            url_for("t_media.getThumbnail_tmedias", id_media=id_media, w=200, h=200),
-        )
-        assert response.status_code == 200
-
-        response = self.client.get(
-            url_for("t_media.getThumbnail_tmedias", id_media=id_media, w=200),
-        )
-        assert response.status_code == 200
-
-        response = self.client.get(
-            url_for("t_media.getThumbnail_tmedias", id_media=id_media, h=200),
-        )
-        assert response.status_code == 200
+        print(response.headers)
+        assert response.status_code == expected_status_code

--- a/apptax/tests/test_media.py
+++ b/apptax/tests/test_media.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from apptax.taxonomie.models import BibTypesMedia, TMedias
 import pytest
 from flask import url_for, current_app
 
@@ -37,6 +38,21 @@ def user():
         uar = UserApplicationRight(role=u, profil=p, application=a)
         db.session.add(uar)
     return u
+
+
+@pytest.fixture
+def media():
+    test_dir_absolute_path = os.path.dirname(os.path.abspath(__file__))
+    with db.session.begin_nested():
+        media = TMedias(
+            titre="test",
+            chemin=os.path.join(test_dir_absolute_path, "assets", "coccinelle.jpg"),
+            is_public=True,
+            types=BibTypesMedia.query.first(),
+        )
+        db.session.add(media)
+    db.session.commit()
+    return media
 
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
@@ -117,7 +133,9 @@ class TestAPIMedia:
     #     id_media = json.loads(response.data)["id_media"]
     #     self.get_thumbnail(id_media)
 
-    def get_thumbnail(self, id_media):
+    def test_get_thumbnail(self, media):
+        id_media = media.id_media
+
         response = self.client.get(
             url_for("t_media.getThumbnail_tmedias", id_media=id_media),
         )

--- a/apptax/tests/test_media.py
+++ b/apptax/tests/test_media.py
@@ -140,6 +140,7 @@ class TestAPIMedia:
             (dict(w=100), 200),
             (dict(h=100), 200),
             (dict(w=100, h=100), 200),
+            (dict(w=100, h=-1), 403),
             (dict(w="a", h="b"), 403),
             (dict(h="b"), 403),
         ],
@@ -148,7 +149,8 @@ class TestAPIMedia:
         id_media = media.id_media
 
         response: Response = self.client.get(
-            url_for("t_media.getThumbnail_tmedias", id_media=id_media, **get_params),
+            url_for(
+                "t_media.getThumbnail_tmedias", id_media=id_media, **get_params, regenerate="true"
+            ),
         )
-        print(response.headers)
         assert response.status_code == expected_status_code

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 **🚀 Nouveautés**
 
 - La limite du nombre de caractères dans la colonne `source` des médias est levée (#595 par @jacquesfize,@amandine-sahl) 
+- Ajout de la possibilité sur la route `/thumbnail/<int:id_media>` d'indiquer seulement la hauteur ou la largeur de la minitiature souhaitée (#594 par @jacquesfize)
 
 
 2.1.0 (2024-12-06)


### PR DESCRIPTION
This PR propose to enable the thumbnail generation with only its width indicated. 

resolves #593 