### PR TITLE
feat(media) : increase the `t_medias.source` varchar size

### DIFF
--- a/apptax/migrations/versions/2c68a907f74c_increase_t_medias_source_size.py
+++ b/apptax/migrations/versions/2c68a907f74c_increase_t_medias_source_size.py
@@ -1,0 +1,28 @@
+"""increase t_medias.source size
+
+Revision ID: 2c68a907f74c
+Revises: 3c4762751898
+Create Date: 2024-12-19 10:31:05.778720
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2c68a907f74c'
+down_revision = '3c4762751898'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('t_medias', 'source',
+        type_=sa.Unicode(),
+        existing_nullable=True,schema='taxonomie')
+
+
+def downgrade():
+    op.alter_column('t_medias', 'source',
+        type_=sa.VARCHAR(length=25),
+        existing_nullable=True,schema='taxonomie')

--- a/apptax/migrations/versions/2c68a907f74c_increase_t_medias_source_size.py
+++ b/apptax/migrations/versions/2c68a907f74c_increase_t_medias_source_size.py
@@ -5,24 +5,29 @@ Revises: 3c4762751898
 Create Date: 2024-12-19 10:31:05.778720
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '2c68a907f74c'
-down_revision = '3c4762751898'
+revision = "2c68a907f74c"
+down_revision = "3c4762751898"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.alter_column('t_medias', 'source',
-        type_=sa.Unicode(),
-        existing_nullable=True,schema='taxonomie')
+    op.alter_column(
+        "t_medias", "source", type_=sa.Unicode(), existing_nullable=True, schema="taxonomie"
+    )
 
 
 def downgrade():
-    op.alter_column('t_medias', 'source',
+    op.alter_column(
+        "t_medias",
+        "source",
         type_=sa.VARCHAR(length=25),
-        existing_nullable=True,schema='taxonomie')
+        existing_nullable=True,
+        schema="taxonomie",
+    )

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -174,7 +174,11 @@ class Taxref(db.Model):
 
     status = db.relationship("VBdcStatus", order_by="VBdcStatus.lb_type_statut")
     synonymes = db.relationship(
-        "Taxref", foreign_keys=[cd_ref], primaryjoin="Taxref.cd_ref == Taxref.cd_ref", uselist=True
+        "Taxref",
+        foreign_keys=[cd_ref],
+        primaryjoin="Taxref.cd_ref == Taxref.cd_ref",
+        uselist=True,
+        post_update=True,
     )
     parent = db.relationship("Taxref", primaryjoin=foreign(cd_sup) == remote(cd_ref))
     attributs = db.relationship("CorTaxonAttribut", back_populates="taxon")

--- a/apptax/tests/fixtures.py
+++ b/apptax/tests/fixtures.py
@@ -34,7 +34,6 @@ def noms_without_listexample():
     with db.session.begin_nested():
         for cd_nom, cd_ref, nom_francais, comments, attr in bibnom_exemple:
             nom = Taxref.query.get(cd_nom)
-            db.session.add(nom)
             noms.append(nom)
     return noms
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+
+2.1.1 (unreleased)
+------------------
+
+**🚀 Nouveautés**
+
+- La limite du nombre de caractères dans la colonne `source` des médias est levée (#595 par @jacquesfize,@amandine-sahl) 
+
+
 2.1.0 (2024-12-06)
 ------------------
 


### PR DESCRIPTION
resolves #592 

Fix on Taxref with relationship synonymes which points to other rows including the current row itself -> https://docs.sqlalchemy.org/en/20/orm/relationship_persistence.html#rows-that-point-to-themselves-mutually-dependent-rows

