### PR TITLE
Taxref - migration : increase column text size

### DIFF
--- a/apptax/taxonomie/commands/migrate_taxref/data/changes_detection/1.1_taxref_changes_detections.sql
+++ b/apptax/taxonomie/commands/migrate_taxref/data/changes_detection/1.1_taxref_changes_detections.sql
@@ -33,7 +33,7 @@ LEFT OUTER JOIN  media m ON i.cd_ref = m.cd_ref;
 
 
 ALTER TABLE tmp_taxref_changes.comp_grap ADD cas varchar(50);
-ALTER TABLE tmp_taxref_changes.comp_grap ADD action varchar(500);
+ALTER TABLE tmp_taxref_changes.comp_grap ADD action text;
 
 -- 'no changes' =  Cas ou il n'y a aucun changement
 --  cd_ref initial correspond au cd_ref final


### PR DESCRIPTION
Correction erreur dans le script de migration, lorsque de nombreux attributs ou valeurs d'attibuts long.