### PR TITLE
Ajout page d'information sur taxref et version de taxhub - cf #328

### DIFF
--- a/apptax/admin/admin.py
+++ b/apptax/admin/admin.py
@@ -37,6 +37,7 @@ def taxhub_admin_addview(app, admin, category=None):
             BibAttributsView,
             LoginView,
             BibThemesView,
+            SummaryView,
         )
 
         static_folder = os.path.join(adresses.root_path, "static")
@@ -83,6 +84,15 @@ def taxhub_admin_addview(app, admin, category=None):
                 BibThemes,
                 db.session,
                 name="Thèmes",
+                category=category,
+                static_folder=static_folder,
+            )
+        )
+
+        admin.add_view(
+            SummaryView(
+                name="Informations",
+                endpoint="summary",
                 category=category,
                 static_folder=static_folder,
             )

--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -720,6 +720,7 @@ class BibAttributsView(FlaskAdminProtectedMixin, RegneAndGroupFormMixin, ModelVi
         ],
     }
 
+
 from flask_admin import BaseView, expose
 
 

--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -29,7 +29,7 @@ from wtforms import Form, BooleanField, SelectField, PasswordField, StringField
 
 from wtforms.validators import ValidationError, DataRequired, Length
 
-from apptax.database import db
+from apptax.database import db, TAXHUB_VERSION
 from apptax.taxonomie.models import (
     BibThemes,
     Taxref,
@@ -54,6 +54,7 @@ from apptax.admin.filters import (
 from apptax.admin.mixins import RegneAndGroupFormMixin
 
 from apptax.admin.forms import ImageUploadFieldWithoutDelete, TAdditionalAttributForm
+from apptax.taxonomie.repositories import TaxrefInfoRepository
 
 log = logging.getLogger(__name__)
 
@@ -718,3 +719,22 @@ class BibAttributsView(FlaskAdminProtectedMixin, RegneAndGroupFormMixin, ModelVi
             ("text", "text"),
         ],
     }
+
+from flask_admin import BaseView, expose
+
+
+class SummaryView(BaseView):
+    @expose("/")
+    def index_view(self):
+        taxref_info = TaxrefInfoRepository.getTaxrefInfo()
+
+        args = {
+            "taxref_version": taxref_info["taxref_version"].version,
+            "taxref_maj": taxref_info["taxref_version"].update_date,
+            "taxref_count": taxref_info["taxref_count"],
+            "status_count": taxref_info["status_count"],
+            "enabled_status_count": taxref_info["enabled_status_count"],
+            "TAXHUB_VERSION": TAXHUB_VERSION,
+        }
+
+        return self.render("admin/summary_index.html", args=args)

--- a/apptax/admin/templates/admin/summary_index.html
+++ b/apptax/admin/templates/admin/summary_index.html
@@ -1,0 +1,30 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+<table class="table table-striped table-bordered table-hover model-list">
+    <tr>
+        <td>Version taxref</td>
+        <td>{{ args['taxref_version']}}</td>
+    </tr>
+    <tr>
+        <td>Date de mise à jour de taxref</td>
+        <td>{{ args['taxref_maj']}}</td>
+    </tr>
+    <tr>
+        <td>Nombre de noms</td>
+        <td>{{ args['taxref_count']}} </td>
+    </tr>
+    <tr>
+        <td>Nombre de statuts</td>
+        <td>{{ args['status_count']}} </td>
+    </tr>
+    <tr>
+        <td>Nombre de statuts actifs</td>
+        <td>{{ args['enabled_status_count']}} </td>
+    </tr>
+    <tr>
+        <td>Version de taxhub</td>
+        <td>{{ args['TAXHUB_VERSION']}}</td>
+    </tr>
+</table>
+
+{% endblock %}

--- a/apptax/admin/templates/admin/summary_index.html
+++ b/apptax/admin/templates/admin/summary_index.html
@@ -2,11 +2,11 @@
 {% block body %}
 <table class="table table-striped table-bordered table-hover model-list">
     <tr>
-        <td>Version taxref</td>
+        <td>Version de Taxref</td>
         <td>{{ args['taxref_version']}}</td>
     </tr>
     <tr>
-        <td>Date de mise à jour de taxref</td>
+        <td>Date de mise à jour de Taxref</td>
         <td>{{ args['taxref_maj']}}</td>
     </tr>
     <tr>
@@ -22,7 +22,7 @@
         <td>{{ args['enabled_status_count']}} </td>
     </tr>
     <tr>
-        <td>Version de taxhub</td>
+        <td>Version de TaxHub</td>
         <td>{{ args['TAXHUB_VERSION']}}</td>
     </tr>
 </table>

--- a/apptax/database.py
+++ b/apptax/database.py
@@ -1,7 +1,15 @@
+import sys
 from os import environ
 from importlib import import_module
+from pathlib import Path
 
 from flask_sqlalchemy import SQLAlchemy
+
+if sys.version_info < (3, 9):
+    from importlib_metadata import version, PackageNotFoundError
+else:
+    from importlib.metadata import version, PackageNotFoundError
+
 
 db_path = environ.get("FLASK_SQLALCHEMY_DB")
 if db_path and db_path != f"{__name__}.db":
@@ -11,3 +19,11 @@ if db_path and db_path != f"{__name__}.db":
 else:
     db = SQLAlchemy()
     environ["FLASK_SQLALCHEMY_DB"] = f"{__name__}.db"
+
+
+ROOT_DIR = Path(__file__).absolute().parent.parent
+try:
+    TAXHUB_VERSION = version("taxhub")
+except PackageNotFoundError:
+    with open(str((ROOT_DIR / "VERSION"))) as v:
+        TAXHUB_VERSION = v.read()

--- a/apptax/taxonomie/commands/taxref.py
+++ b/apptax/taxonomie/commands/taxref.py
@@ -11,7 +11,7 @@ from apptax.taxonomie.commands.migrate_taxref.commands_v15 import migrate_to_v15
 from apptax.taxonomie.commands.migrate_taxref.commands_v16 import migrate_to_v16
 from apptax.taxonomie.commands.migrate_taxref.commands_v17 import migrate_to_v17
 from apptax.taxonomie.commands.migrate_taxref.commands_v18 import migrate_to_v18
-from apptax.taxonomie.models import Taxref, TaxrefBdcStatutText, TMetaTaxref
+from apptax.taxonomie.models import Taxref
 
 from .utils import truncate_bdc_statuts
 from .taxref_v14 import import_v14, import_bdc_v14
@@ -29,6 +29,7 @@ from .taxref_v18 import import_v18, import_bdc_v18
 from .migrate_taxref.test_commands_migrate import test_migrate_taxref
 
 from apptax.taxonomie.models import Taxref
+from apptax.taxonomie.repositories import TaxrefInfoRepository
 
 import logging
 
@@ -43,20 +44,16 @@ def taxref():
 @taxref.command()
 @with_appcontext
 def info():
+    taxref_info = TaxrefInfoRepository.getTaxrefInfo()
     click.echo("TaxRef :")
-    taxref_version = db.session.scalar(
-        select(TMetaTaxref).order_by(TMetaTaxref.update_date.desc()).limit(1)
+    click.echo(
+        f"\tVersion de taxref : {taxref_info['taxref_version'].version} ({taxref_info['taxref_version'].update_date})"
     )
-
-    click.echo(f"\tVersion de taxref : {taxref_version.version} ({taxref_version.update_date})")
-    taxref_count = db.session.scalar(db.select(func.count(Taxref.cd_nom)))
-    click.echo(f"\tNombre de taxons : {taxref_count}")
-    status_count = db.session.scalar(db.select(func.count(TaxrefBdcStatutText.id_text)))
-    enabled_status_count = db.session.scalar(
-        select(func.count(TaxrefBdcStatutText.id_text)).where(TaxrefBdcStatutText.enable == True)
-    )
+    click.echo(f"\tNombre de taxons : {taxref_info['taxref_count']}")
     click.echo("Base de connaissances :")
-    click.echo(f"\tStatuts (actifs / total) : {enabled_status_count} / {status_count}")
+    click.echo(
+        f"\tStatuts (actifs / total) : {taxref_info['enabled_status_count']} / {taxref_info['status_count']}"
+    )
 
 
 @taxref.command(help="Supprimer toutes les données TaxRef.")

--- a/apptax/taxonomie/repositories.py
+++ b/apptax/taxonomie/repositories.py
@@ -1,13 +1,14 @@
 import logging
 from typing import List, Dict, TypedDict
 
-from sqlalchemy import select, case, and_
+from sqlalchemy import select, and_, func
 from sqlalchemy.orm import joinedload, aliased
 
 from . import db
 from ..utils.utilssqlalchemy import dict_merge
 from .models import (
     BibTaxrefRangs,
+    TMetaTaxref,
     TaxrefBdcStatutCorTextValues,
     TaxrefBdcStatutTaxon,
     TaxrefBdcStatutText,
@@ -157,3 +158,38 @@ class BdcStatusRepository:
             else:
                 results[cd_type_statut] = res
         return results
+
+
+class TaxrefInfoRepository:
+    @staticmethod
+    def getTaxrefInfo():
+        """
+        Retourne des informations sur les données de Taxref.
+
+        Returns
+        -------
+        dict
+            Dictionnaire contenant les informations suivantes :
+            - taxref_version: Dernière version de Taxref
+            - taxref_count: Nombre de taxons
+            - status_count: Nombre de statuts
+            - enabled_status_count: Nombre de statuts actifs
+        """
+        taxref_version = db.session.scalar(
+            select(TMetaTaxref).order_by(TMetaTaxref.update_date.desc()).limit(1)
+        )
+
+        taxref_count = db.session.scalar(db.select(func.count(Taxref.cd_nom)))
+        status_count = db.session.scalar(db.select(func.count(TaxrefBdcStatutText.id_text)))
+        enabled_status_count = db.session.scalar(
+            select(func.count(TaxrefBdcStatutText.id_text)).where(
+                TaxrefBdcStatutText.enable == True
+            )
+        )
+
+        return {
+            "taxref_version": taxref_version,
+            "taxref_count": taxref_count,
+            "status_count": status_count,
+            "enabled_status_count": enabled_status_count,
+        }

--- a/apptax/tests/test_taxref_last_version.py
+++ b/apptax/tests/test_taxref_last_version.py
@@ -8,11 +8,18 @@ from sqlalchemy import select, func
 from apptax.database import db
 from apptax.taxonomie.models import Taxref, TaxrefBdcStatutText, TMetaTaxref, TaxrefLiens
 from apptax.taxonomie.commands.utils import populate_enable_bdc_statut_text
-
+from apptax.taxonomie.repositories import TaxrefInfoRepository
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestPopulateTaxref:
     """Test if taxref data are correctly populated"""
+
+    def test_taxref_info(self):
+        taxref_info = TaxrefInfoRepository.getTaxrefInfo()
+        assert taxref_info["taxref_version"].version == 18
+        assert taxref_info["taxref_count"] == 708685
+        assert taxref_info["status_count"] == 912
+        assert taxref_info["enabled_status_count"] == 912
 
     def test_count_taxref(self):
         nb_taxref = db.session.scalar(select(func.count()).select_from(Taxref))

--- a/apptax/tests/test_taxref_last_version.py
+++ b/apptax/tests/test_taxref_last_version.py
@@ -10,6 +10,7 @@ from apptax.taxonomie.models import Taxref, TaxrefBdcStatutText, TMetaTaxref, Ta
 from apptax.taxonomie.commands.utils import populate_enable_bdc_statut_text
 from apptax.taxonomie.repositories import TaxrefInfoRepository
 
+
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestPopulateTaxref:
     """Test if taxref data are correctly populated"""

--- a/apptax/utils/config/config_schema.py
+++ b/apptax/utils/config/config_schema.py
@@ -5,6 +5,8 @@ Description des options de configuration
 from marshmallow import Schema, fields, validates_schema, ValidationError, post_load, pre_load
 from marshmallow.validate import OneOf, Regexp, Email, Length
 
+from apptax.database import TAXHUB_VERSION
+
 
 class TaxhubAppConf(Schema):
     API_PREFIX = fields.String(
@@ -38,3 +40,4 @@ class TaxhubSchemaConf(TaxhubAppConf):
     PASS_METHOD = fields.String(load_default="hash")
     FLASK_ADMIN_SWATCH = fields.String(load_default="cerulean")
     FLASK_ADMIN_FLUID_LAYOUT = fields.Boolean(load_default=True)
+    TAXHUB_VERSION = fields.String(load_default=TAXHUB_VERSION.strip())


### PR DESCRIPTION
Ajout page d'informations accessibles en web reprenant les données de la commande `flask taxref info`
<img width="941" height="358" alt="image" src="https://github.com/user-attachments/assets/50028c12-1ce8-4963-9218-12a5be59a4bf" />

https://github.com/PnX-SI/TaxHub/issues/328