### PR TITLE
Ajout fonctionnalité d'export depuis la vue taxref - cf #632

### DIFF
--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -313,9 +313,32 @@ class TaxrefView(
     ModelView,
 ):
     can_create = False
-    can_export = False
     can_delete = False
     can_view_details = True
+    # Configuration de l'export
+    can_export = True
+    export_max_rows = 10000
+    column_export_list = (
+        "regne",
+        "group1_inpn",
+        "group2_inpn",
+        "group3_inpn",
+        "classe",
+        "ordre",
+        "famille",
+        "cd_nom",
+        "cd_ref",
+        "nom_complet",
+        "nom_valide",
+        "nom_vern",
+        "rang",
+        "listes",
+        "attributs",
+        "nb_medias",
+    )
+    column_formatters_export = dict(
+        listes=lambda v, c, m, p: ",".join([l.nom_liste for l in m.listes])
+    )
 
     @property
     def can_edit(self):

--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -337,12 +337,17 @@ class TaxrefView(
         "nb_medias",
     )
     column_formatters_export = dict(
-        listes=lambda v, c, m, p: ",".join([l.nom_liste for l in m.listes])
+        listes=lambda v, c, m, p: ",".join([l.nom_liste for l in m.listes]),
+        attributs=lambda v, c, m, p: ",".join([a.bib_attribut.nom_attribut for a in m.attributs]),
     )
 
     @property
     def can_edit(self):
         return self._can_action(2)
+
+    @property
+    def can_export(self):
+        return self._can_action(0)
 
     inline_models = (InlineMediaForm(),)
 


### PR DESCRIPTION
Ajout de la possibilité d'exporter les données de Taxref avec une limitation a 10000 données. 

Ainsi l'utilisateur peut réaliser des filtres comme taxon appartenant à cette liste, ... et exporter le résultat