### PR TITLE
Update filemanager.py

### DIFF
--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 from shutil import rmtree
 from PIL import Image, ImageOps
+from io import BytesIO
 
 from werkzeug.utils import secure_filename
 
 from flask import current_app
 
 import urllib.request
-from urllib.error import HTTPError
+from urllib.error import URLError, HTTPError
 from apptax.utils.errors import TaxhubError
 
 logger = logging.getLogger()
@@ -121,17 +122,23 @@ FILEMANAGER = LocalFileManagerService()
 # METHOD #2: PIL
 def url_to_image(url):
     """
-    Récupération d'une image à partir d'une url
+    Récupération d'une image à partir d'une url avec TIMEOUT
     """
+    TIMEOUT = 5.0  # secondes
+    # Récupération image (échoue si source externe non disponible)
     try:
-        local_filename, headers = urllib.request.urlretrieve(url)
-    except HTTPError as e:
-        raise TaxhubError(e.reason)
+        with urllib.request.urlopen(urllib.request.Request(url), timeout=TIMEOUT) as r:
+            data = r.read()
+    except (HTTPError, URLError, Exception) as e:
+        logger.warning("url_to_image GET failed url=%s err=%r", url, e)
+        raise TaxhubError(f"GET failed for {url}: {e}")
+
+    # Décodage image (échoue vite si non-image)
     try:
-        img = Image.open(local_filename)
-        urllib.request.urlcleanup()
+        img = Image.open(BytesIO(data))
+        img.load()
         return img
-    except IOError:
+    except Exception:
         raise TaxhubError("Media is not an image")
 
 


### PR DESCRIPTION
patch + log en cas de source de photo non disponible (aka as INPN is down)
Ce qui bloque toutes les modifications sur un taxon, dont l'affectation à une liste de taxon.

dans apptax\taxonomie\models.py
after_update_t_media est déclenché et bloque car ne reçoit pas l'image
```
[ERROR] Failed to update record
urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
```


le timeout de l'url est a 5s car peu de photos encore, mais pour certains taxons j'ai 10 photos donc 50sec où l'interface ne répond plus. Ce qui est mieux que juste pas marcher avec 
 ou un timeout de taxhub 😅
(j'imagine possible de mettre a 3s, mais 5s c'est mieux en cas d'image disponible mais lourde)
