### PR TITLE
Ajout paramètres MEDIA_SUBFOLDER et THUMB_SUBFOLDER

### DIFF
--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -268,7 +268,11 @@ class InlineMediaForm(InlineFormAdmin):
         "chemin": FileUploadFieldWithoutDelete(
             label="Téléverser un fichier",
             namegen=taxref_media_file_name,
-            base_path=Path(current_app.config["MEDIA_FOLDER"], "taxhub").absolute(),
+            base_path=Path(
+                current_app.config["MEDIA_FOLDER"],
+                "taxhub",
+                current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+            ).absolute(),
             description="Téléverser le média que vous souhaitez associer au taxon",
         )
     }
@@ -600,7 +604,11 @@ class TMediasView(FlaskAdminProtectedMixin, ModelView):
     form_extra_fields = {
         "chemin": FileUploadFieldWithoutDelete(
             label="Téléverser un fichier",
-            base_path=Path(current_app.config["MEDIA_FOLDER"], "taxhub").absolute(),
+            base_path=Path(
+                current_app.config["MEDIA_FOLDER"],
+                "taxhub",
+                current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+            ).absolute(),
             namegen=taxref_media_file_name,
         )
     }

--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -63,8 +63,16 @@ class LocalFileManagerService:
     """
 
     def __init__(self):
-        self.dir_file_base = Path(current_app.config["MEDIA_FOLDER"], "taxhub").absolute()
-        self.dir_thumb_base = self.dir_file_base / "thumb"
+        self.dir_file_base = Path(
+            current_app.config["MEDIA_FOLDER"],
+            "taxhub",
+            current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+        ).absolute()
+        self.dir_thumb_base = Path(
+            current_app.config["MEDIA_FOLDER"],
+            "taxhub",
+            current_app.config["TAXHUB"]["THUMB_SUBFOLDER"]
+        ).absolute()
 
     def _get_media_path_from_db(self, filepath: str) -> str:
         """

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -338,7 +338,14 @@ class TMedias(db.Model):
         if self.url:
             return self.url
         elif self.chemin:
-            return url_for("media_taxhub", filename=self.chemin, _external=True)
+            return url_for(
+                "media_taxhub",
+                filename=Path(
+                    current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"],
+                    self.chemin
+                    ),
+                _external=True
+                )
 
     def __repr__(self):
         return self.titre

--- a/apptax/utils/config/config_schema.py
+++ b/apptax/utils/config/config_schema.py
@@ -18,6 +18,10 @@ class TaxhubAppConf(Schema):
     )
     ID_TYPE_MAIN_PHOTO = fields.Integer(load_default=1)
 
+    # Stockage médias et miniatures au sein du dossier <MEDIA_FOLDER>/taxhub
+    MEDIA_SUBFOLDER = fields.String(load_default="")
+    THUMB_SUBFOLDER = fields.String(load_default="thumb")
+
 
 class TaxhubSchemaConf(TaxhubAppConf):
     SQLALCHEMY_DATABASE_URI = fields.String(


### PR DESCRIPTION
Cette PR ajoute deux paramètres optionnels dans la configuration TaxHub : `MEDIA_SUBFOLDER` et `THUMB_SUBFOLDER`, comme discuté dans le ticket #580.

Ces paramètres permettent de distinguer, au sein du dossier `MEDIA_FOLDER/taxhub`, l'emplacement où sont stockés les médias eux même de celui où sont stockés les miniatures. Avec la configuration actuelle, les médias sont stockés à la racine de  `MEDIA_FOLDER/taxhub`, et les miniatures dans un dossier `MEDIA_FOLDER/taxhub/thumb`. 

C'est particulièrement utile dans le contecte d'un stockage des médias sur un serveur S3 : on cherchera alors à limiter au maximum le trafic entrant et sortant du serveur. Une bonne pratique est alors de stocker les miniatures "en local" sur le serveur, car elles sont appelées plus fréquemment mais occupent moins d'espace, et d'avoir les médias eux même sur le S3, car plus lourds mais appelés plus rarement (au clic sur la miniature).

Si les paramètres ne sont pas définis, le comportement actuel est conservé par défaut.

Testé sur un TaxHub installé au sein d'une instance GeoNature, mais pas sur un TaxHub standalone : est-ce que ça marchera avec le `current_app.config["TAXHUB"]` ?

Je suis preneur de retours notamment sur la logique et le nommage des paramètres !