### PR TITLE
Feat/s3 subfolder

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -109,6 +109,11 @@ jobs:
         pytest -v --cov --cov-report xml
       env:
         TAXHUB_CONFIG_FILE: config/test_config.toml
+    - name: Test extra config with pytest
+      run: |
+        pytest -v apptax/tests/test_config_media.py
+      env:
+        TAXHUB_CONFIG_FILE: config/test_config_medias.toml
     - name: Upload coverage to Codecov
       if: ${{ matrix.debian-version == '12' && matrix.sqlalchemy-version == '1.4' }}
       uses: codecov/codecov-action@v4

--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -268,7 +268,11 @@ class InlineMediaForm(InlineFormAdmin):
         "chemin": FileUploadFieldWithoutDelete(
             label="Téléverser un fichier",
             namegen=taxref_media_file_name,
-            base_path=Path(current_app.config["MEDIA_FOLDER"], "taxhub").absolute(),
+            base_path=Path(
+                current_app.config["MEDIA_FOLDER"],
+                "taxhub",
+                current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+            ).absolute(),
             description="Téléverser le média que vous souhaitez associer au taxon",
         )
     }
@@ -600,7 +604,11 @@ class TMediasView(FlaskAdminProtectedMixin, ModelView):
     form_extra_fields = {
         "chemin": FileUploadFieldWithoutDelete(
             label="Téléverser un fichier",
-            base_path=Path(current_app.config["MEDIA_FOLDER"], "taxhub").absolute(),
+            base_path=Path(
+                current_app.config["MEDIA_FOLDER"],
+                "taxhub",
+                current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+            ).absolute(),
             namegen=taxref_media_file_name,
         )
     }

--- a/apptax/admin/admin_view.py
+++ b/apptax/admin/admin_view.py
@@ -29,7 +29,7 @@ from wtforms import Form, BooleanField, SelectField, PasswordField, StringField
 
 from wtforms.validators import ValidationError, DataRequired, Length
 
-from apptax.database import db, TAXHUB_VERSION
+from apptax.database import db, TAXHUB_VERSION, get_media_folder
 from apptax.taxonomie.models import (
     BibThemes,
     Taxref,
@@ -268,11 +268,7 @@ class InlineMediaForm(InlineFormAdmin):
         "chemin": FileUploadFieldWithoutDelete(
             label="Téléverser un fichier",
             namegen=taxref_media_file_name,
-            base_path=Path(
-                current_app.config["MEDIA_FOLDER"],
-                "taxhub",
-                current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
-            ).absolute(),
+            base_path=get_media_folder().absolute(),
             description="Téléverser le média que vous souhaitez associer au taxon",
         )
     }
@@ -604,11 +600,7 @@ class TMediasView(FlaskAdminProtectedMixin, ModelView):
     form_extra_fields = {
         "chemin": FileUploadFieldWithoutDelete(
             label="Téléverser un fichier",
-            base_path=Path(
-                current_app.config["MEDIA_FOLDER"],
-                "taxhub",
-                current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
-            ).absolute(),
+            base_path=get_media_folder().absolute(),
             namegen=taxref_media_file_name,
         )
     }

--- a/apptax/app.py
+++ b/apptax/app.py
@@ -62,13 +62,11 @@ def create_app():
     app.config.update(config)
     app.config.from_prefixed_env(prefix="TAXHUB")
 
+    # Enable serving of media files for Taxhub
+    taxhub_folder = "taxhub"
     if app.config["MEDIA_SUBFOLDER"]:
-        taxhub_folder = "taxhub/" + app.config["MEDIA_SUBFOLDER"]
-    else:
-        taxhub_folder = "taxhub"
-
+        taxhub_folder = taxhub_folder + "/" + app.config["MEDIA_SUBFOLDER"]
     media_path = Path(app.config["MEDIA_FOLDER"], taxhub_folder).absolute()
-    # Enable serving of media files
     app.add_url_rule(
         f"/{app.config['MEDIA_FOLDER']}/{taxhub_folder}/<path:filename>",
         view_func=lambda filename: send_from_directory(media_path, filename),

--- a/apptax/app.py
+++ b/apptax/app.py
@@ -62,11 +62,15 @@ def create_app():
     app.config.update(config)
     app.config.from_prefixed_env(prefix="TAXHUB")
 
-    media_path = Path(app.config["MEDIA_FOLDER"], "taxhub").absolute()
+    if app.config["MEDIA_SUBFOLDER"]:
+        taxhub_folder = "taxhub/" + app.config["MEDIA_SUBFOLDER"]
+    else:
+        taxhub_folder = "taxhub"
 
+    media_path = Path(app.config["MEDIA_FOLDER"], taxhub_folder).absolute()
     # Enable serving of media files
     app.add_url_rule(
-        f"/{media_path}/<path:filename>",
+        f"/{app.config['MEDIA_FOLDER']}/{taxhub_folder}/<path:filename>",
         view_func=lambda filename: send_from_directory(media_path, filename),
         endpoint="media_taxhub",
     )

--- a/apptax/database.py
+++ b/apptax/database.py
@@ -1,4 +1,5 @@
 import sys
+from flask import current_app
 from os import environ
 from importlib import import_module
 from pathlib import Path
@@ -28,6 +29,24 @@ try:
 except PackageNotFoundError:
     with open(str((ROOT_DIR / "VERSION"))) as v:
         TAXHUB_VERSION = v.read()
+
+
+def get_media_folder() -> Path:
+    if "TAXHUB" in current_app.config:
+        media_subfolder = current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+    else:
+        media_subfolder = current_app.config["MEDIA_SUBFOLDER"]
+
+    return Path(current_app.config["MEDIA_FOLDER"], "taxhub", media_subfolder)
+
+
+def get_media_thumb_folder() -> Path:
+    if "TAXHUB" in current_app.config:
+        media_subfolder = current_app.config["TAXHUB"]["THUMB_SUBFOLDER"]
+    else:
+        media_subfolder = current_app.config["THUMB_SUBFOLDER"]
+
+    return Path(current_app.config["MEDIA_FOLDER"], "taxhub", media_subfolder).absolute()
 
 
 def generate_user_agent() -> str:

--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -63,8 +63,16 @@ class LocalFileManagerService:
     """
 
     def __init__(self):
-        self.dir_file_base = Path(current_app.config["MEDIA_FOLDER"], "taxhub").absolute()
-        self.dir_thumb_base = self.dir_file_base / "thumb"
+        self.dir_file_base = Path(
+            current_app.config["MEDIA_FOLDER"],
+            "taxhub",
+            current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
+        ).absolute()
+        self.dir_thumb_base = Path(
+            current_app.config["MEDIA_FOLDER"],
+            "taxhub",
+            current_app.config["TAXHUB"]["THUMB_SUBFOLDER"]
+        ).absolute()
 
     def _get_media_path_from_db(self, filepath: str) -> str:
         """

--- a/apptax/taxonomie/filemanager.py
+++ b/apptax/taxonomie/filemanager.py
@@ -18,7 +18,7 @@ from flask import current_app
 import urllib.request
 from urllib.error import URLError, HTTPError
 from apptax.utils.errors import TaxhubError
-from apptax.database import generate_user_agent
+from apptax.database import generate_user_agent, get_media_folder, get_media_thumb_folder
 
 logger = logging.getLogger()
 
@@ -63,16 +63,8 @@ class LocalFileManagerService:
     """
 
     def __init__(self):
-        self.dir_file_base = Path(
-            current_app.config["MEDIA_FOLDER"],
-            "taxhub",
-            current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"]
-        ).absolute()
-        self.dir_thumb_base = Path(
-            current_app.config["MEDIA_FOLDER"],
-            "taxhub",
-            current_app.config["TAXHUB"]["THUMB_SUBFOLDER"]
-        ).absolute()
+        self.dir_file_base = get_media_folder().absolute()
+        self.dir_thumb_base = get_media_thumb_folder().absolute()
 
     def _get_media_path_from_db(self, filepath: str) -> str:
         """
@@ -182,9 +174,6 @@ class LocalFileManagerService:
 
         resizeImg.save(thumbpath_full)
         return thumbpath_full
-
-
-FILEMANAGER = LocalFileManagerService()
 
 
 # METHOD #2: PIL

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -338,7 +338,14 @@ class TMedias(db.Model):
         if self.url:
             return self.url
         elif self.chemin:
-            return url_for("media_taxhub", filename=self.chemin, _external=True)
+            return url_for(
+                "media_taxhub",
+                filename=Path(
+                    current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"],
+                    self.chemin
+                    ),
+                _external=True
+                )
 
     def __repr__(self):
         return self.titre

--- a/apptax/taxonomie/models.py
+++ b/apptax/taxonomie/models.py
@@ -338,14 +338,7 @@ class TMedias(db.Model):
         if self.url:
             return self.url
         elif self.chemin:
-            return url_for(
-                "media_taxhub",
-                filename=Path(
-                    current_app.config["TAXHUB"]["MEDIA_SUBFOLDER"],
-                    self.chemin
-                    ),
-                _external=True
-                )
+            return url_for("media_taxhub", filename=self.chemin, _external=True)
 
     def __repr__(self):
         return self.titre
@@ -610,6 +603,6 @@ Taxref.nb_attributs = deferred(
 @event.listens_for(TMedias, "after_update")
 def after_update_t_media(mapper, connection, target):
     # Regénération des thumnails des médias quand modification du média
-    from apptax.taxonomie.filemanager import FILEMANAGER
+    from apptax.taxonomie.filemanager import LocalFileManagerService
 
-    FILEMANAGER.create_thumb(target, (300, 400), regenerate=True)
+    LocalFileManagerService().create_thumb(target, (300, 400), regenerate=True)

--- a/apptax/taxonomie/routestmedias.py
+++ b/apptax/taxonomie/routestmedias.py
@@ -8,8 +8,7 @@ from werkzeug.exceptions import Forbidden
 
 from .models import TMedias, BibTypesMedia
 from .schemas import TMediasSchema, BibTypesMediaSchema
-
-from .filemanager import FILEMANAGER
+from apptax.taxonomie.filemanager import LocalFileManagerService
 
 DEFAULT_THUMBNAIL_SIZE = (300, 400)
 
@@ -109,7 +108,7 @@ def getThumbnail_tmedias(id_media):
         size = (int(width_params), int(height_params))
         force = True
 
-    thumbpath = FILEMANAGER.create_thumb(media, size, force, regenerate)
+    thumbpath = LocalFileManagerService().create_thumb(media, size, force, regenerate)
     if thumbpath:
         return send_file(
             os.path.join(Path(current_app.config["MEDIA_FOLDER"]).absolute(), "taxhub", thumbpath)

--- a/apptax/tests/conftest.py
+++ b/apptax/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from apptax.database import db
 from apptax.app import create_app
 from utils_flask_sqla.tests.utils import JSONClient
@@ -11,6 +10,7 @@ def _app():
     app.testing = True
     app.test_client_class = JSONClient
     app.config["SERVER_NAME"] = "taxhub.geonature.fr"  # required by url_for
+
     with app.app_context():
         yield app
 

--- a/apptax/tests/test_config_media.py
+++ b/apptax/tests/test_config_media.py
@@ -1,0 +1,91 @@
+import json
+import os
+import io
+import pytest
+from pathlib import Path
+
+from sqlalchemy import select
+from flask import url_for, current_app, Response
+from apptax.database import db, get_media_folder, get_media_thumb_folder
+
+from apptax.taxonomie.models import BibTypesMedia, TMedias
+
+from pypnusershub.db.models import (
+    User,
+    Organisme,
+    Application,
+    Profils,
+    UserApplicationRight,
+    AppUser,
+)
+from pypnusershub.tests.utils import set_logged_user_cookie
+from schema import Schema, Optional, Or
+from apptax.taxonomie.models import Taxref
+from .fixtures import noms_example, attribut_example, liste, users
+
+from PIL import Image
+
+
+@pytest.mark.usefixtures("client_class", "temporary_transaction")
+class TestConfigS3Media:
+    def test_get_media_subfolder(self, monkeypatch, users):
+        set_logged_user_cookie(self.client, users["admin"])
+
+        thumb_file_name = f"100x100.png"
+
+        # --- Détermination des répertoires attendus selon la configuration ---
+        # Lorsque MEDIA_FOLDER vaut "media", on utilise l'arborescence standard.
+        # Sinon, le code utilise des sous-répertoires spécifiques (sub_medias/sub_thumb).
+        if current_app.config["MEDIA_FOLDER"] == "media":
+            dir_media_test = Path(current_app.config["MEDIA_FOLDER"], "taxhub")
+            dir_thumb_test = Path(current_app.config["MEDIA_FOLDER"], "taxhub", "thumb")
+        else:
+            dir_media_test = Path(current_app.config["MEDIA_FOLDER"], "taxhub", "sub_medias")
+            dir_thumb_test = Path(current_app.config["MEDIA_FOLDER"], "taxhub", "sub_thumb")
+
+        dir_thumb_fct = get_media_thumb_folder()
+        dir_media_fct = get_media_folder()
+        # Vérifie que les chemins calculés correspondent bien à ceux attendus
+        assert dir_thumb_fct.absolute() == dir_thumb_test.absolute()
+        assert dir_media_fct.absolute() == dir_media_test.absolute()
+
+        # Upload media
+        f_jpg = open(os.path.join("apptax/tests/assets", "coccinelle.jpg"), "rb")
+        form_taxref = {
+            "medias-0-types": 1,
+            "medias-0-titre": "test",
+            "medias-0-auteur": "test",
+            "medias-0-desc_media": "test",
+            "medias-0-source": "test",
+            "medias-0-is_public": True,
+            "medias-0-chemin": (f_jpg, "coccinelle.jpg"),
+        }
+        req = self.client.post(
+            "taxons/edit/?id=97947&url=/taxons/",
+            data=form_taxref,
+            content_type="multipart/form-data",
+        )
+        f_jpg.close()
+        assert req.status_code == 302
+
+        # --- Vérification côté base de données ---
+
+        # Récupère le taxon et son média nouvellement créé
+
+        tax = db.session.query(Taxref).filter_by(cd_nom=97947).scalar()
+        media = tax.medias[0]
+        media_file = Path(dir_media_fct, "97947_coccinelle.jpg").absolute()
+        # Vérifie que le fichier a bien été créé physiquement
+        assert media_file.is_file() == True
+
+        # --- Test de génération du thumbnail (miniature) ---
+        response: Response = self.client.get(
+            url_for(
+                "t_media.getThumbnail_tmedias", id_media=media.id_media, w=100, regenerate="true"
+            ),
+        )
+        assert response.status_code == 200
+        # Chemin attendu du thumbnail généré (dans dossier/id_media)
+        thumb_file = Path(dir_thumb_fct, str(media.id_media), "100x-1.png").absolute()
+        # Vérifie que la miniature existe bien
+        assert thumb_file.is_file() == True

--- a/apptax/utils/config/config_schema.py
+++ b/apptax/utils/config/config_schema.py
@@ -18,6 +18,10 @@ class TaxhubAppConf(Schema):
     )
     ID_TYPE_MAIN_PHOTO = fields.Integer(load_default=1)
 
+    # Stockage médias et miniatures au sein du dossier <MEDIA_FOLDER>/taxhub
+    MEDIA_SUBFOLDER = fields.String(load_default="")
+    THUMB_SUBFOLDER = fields.String(load_default="thumb")
+
 
 class TaxhubSchemaConf(TaxhubAppConf):
     SQLALCHEMY_DATABASE_URI = fields.String(

--- a/config/taxhub_config.toml.default
+++ b/config/taxhub_config.toml.default
@@ -18,6 +18,11 @@ APPLICATION_ROOT="/"
 # chemin relatif vers le dossier contenant les médias
 MEDIA_FOLDER="media"
 
+# chemin du sous dossier des médias TaxHub (utile pour les configurations s3)
+MEDIA_SUBFOLDER = ""
+# chemin du sous dossier des thumbnail TaxHub
+THUMB_SUBFOLDER ="thumb"
+
 # Méthode de hash du mot de passe
 PASS_METHOD
 

--- a/config/test_config_medias.toml
+++ b/config/test_config_medias.toml
@@ -1,0 +1,7 @@
+SQLALCHEMY_DATABASE_URI = "postgresql://taxhubadmin:taxhubpwd@127.0.0.1:5432/taxhub"
+SECRET_KEY = 'a7e0a755dd3f2c382bac5b5cea6c9329802aeedf39e3f10d0462ffb52c3f5e99'
+
+# Custom media config folder for s3
+MEDIA_FOLDER = "custom_media" 
+MEDIA_SUBFOLDER = "sub_medias" 
+THUMB_SUBFOLDER= "sub_thumb" 


### PR DESCRIPTION
reprise de la PR #664


> Cette PR ajoute deux paramètres optionnels dans la configuration TaxHub : MEDIA_SUBFOLDER et THUMB_SUBFOLDER, comme discuté dans le ticket https://github.com/PnX-SI/TaxHub/issues/580.
Ces paramètres permettent de distinguer, au sein du dossier MEDIA_FOLDER/taxhub, l'emplacement où sont stockés les médias eux même de celui où sont stockés les miniatures. Avec la configuration actuelle, les médias sont stockés à la racine de MEDIA_FOLDER/taxhub, et les miniatures dans un dossier MEDIA_FOLDER/taxhub/thumb.
C'est particulièrement utile dans le contecte d'un stockage des médias sur un serveur S3 : on cherchera alors à limiter au maximum le trafic entrant et sortant du serveur. Une bonne pratique est alors de stocker les miniatures "en local" sur le serveur, car elles sont appelées plus fréquemment mais occupent moins d'espace, et d'avoir les médias eux même sur le S3, car plus lourds mais appelés plus rarement (au clic sur la miniature).
Si les paramètres ne sont pas définis, le comportement actuel est conservé par défaut.
 