### PR TITLE
PostgreSQL fonction get_current_taxref_version

### DIFF
--- a/apptax/migrations/versions/913634ce1da4_get_taxref_version_pg_fct.py
+++ b/apptax/migrations/versions/913634ce1da4_get_taxref_version_pg_fct.py
@@ -5,13 +5,13 @@ Revises: eb7fe5a32655
 Create Date: 2026-06-18 09:34:43.648527
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
-revision = '913634ce1da4'
-down_revision = 'eb7fe5a32655'
+revision = "913634ce1da4"
+down_revision = "eb7fe5a32655"
 branch_labels = None
 depends_on = None
 

--- a/apptax/migrations/versions/913634ce1da4_get_taxref_version_pg_fct.py
+++ b/apptax/migrations/versions/913634ce1da4_get_taxref_version_pg_fct.py
@@ -1,0 +1,39 @@
+"""get_taxref_version_pg_fct
+
+Revision ID: 913634ce1da4
+Revises: eb7fe5a32655
+Create Date: 2026-06-18 09:34:43.648527
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '913634ce1da4'
+down_revision = 'eb7fe5a32655'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        CREATE OR REPLACE FUNCTION taxonomie.get_current_taxref_version()
+            RETURNS integer
+            LANGUAGE sql
+            STABLE
+            PARALLEL SAFE
+        AS
+        $tx_version$
+        SELECT version
+        FROM taxonomie.t_meta_taxref
+        ORDER BY update_date DESC
+        LIMIT 1
+        $tx_version$;
+        """)
+
+
+def downgrade():
+    op.execute("""
+        DROP FUNCTION taxonomie.get_current_taxref_version();
+        """)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.x.x (xx-xx-xxxx)
+
+### 🚀 Nouveautés
+
+- Ajout d'une fonction pour identifier la version utilisée de taxref depuis la table `taxonomie.meta_v_taxref` (#700 par @lpofredc)
+
+
 ## 2.3.1 (12-03-2026)
 
 ### 🚀 Nouveautés


### PR DESCRIPTION
Je propose l'ajout d'une fonction PostgreSQL pour récupérer récupérer le numéro de version TaxRef en cours sur l'instance TaxHub. Pourra remplacer à terme la variable gn_commons.t_parameters si elle a toujours une utilité.

